### PR TITLE
Deploy MCCO Sovereign — Master Chief Commanding Officer of Marketing & Sales

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,9 @@ Monorepo with Cloudflare Workers, Cloudflare Pages, Airtable, Retell AI, and Cla
 - **Gazette**: Available at `/gazette.html` on Command Center deployment
 
 ## Architecture
-- **ck-api-gateway**: Central API — 43 endpoints: inference, leads, agents, workflows, pricing, property intel, campaign, email, intelligence officers (Cloudflare Worker)
+- **ck-api-gateway**: Central API — 53 endpoints: inference, leads, agents, workflows, pricing, property intel, campaign, email, intelligence officers, MCCO sovereign command (Cloudflare Worker)
 - **ck-nemotron-worker**: NVIDIA Nemotron inference endpoint — `/v1/inference`, `/v1/health` (Cloudflare Worker)
-- **ck-command-center**: Dashboard UI for 290-agent fleet + Coastal Key Gazette (Cloudflare Pages)
+- **ck-command-center**: Dashboard UI for 312-agent fleet + Coastal Key Gazette (Cloudflare Pages)
 - **ck-website**: Public-facing website with contact form (Cloudflare Pages)
 - **sentinel-webhook**: Retell call_analyzed → Airtable + Slack pipeline (Cloudflare Worker)
 - **th-sentinel-campaign**: Campaign config, Retell prompts, Airtable field reference
@@ -32,10 +32,42 @@ npm run test:nemotron   # Test Nemotron worker only
 npm run deploy          # Deploy all services
 ```
 
-## Autonomous Fleet (360 units)
-- **290 AI Agents** across 9 divisions: EXC, SEN, OPS, INT, MKT, FIN, VEN, TEC, WEB
+## Autonomous Fleet (382 units)
+- **15 MCCO Agents** — Sovereign Governance: Master Chief Commanding Officer of Marketing & Sales (Ferrari-Standard execution, commands MKT + SEN divisions, CMO reports to MCCO)
+- **297 AI Agents** across 9 operational divisions: EXC, SEN, OPS, INT, MKT, FIN, VEN, TEC, WEB
 - **50 Intelligence Officers** in 5 squads: ALPHA (Infrastructure), BRAVO (Data), CHARLIE (Security), DELTA (Revenue), ECHO (Performance)
 - **20 Email AI Agents** in 4 squads: INTAKE, COMPOSE, NURTURE, MONITOR
+
+## MCCO Command Structure (Sovereign Governance)
+- **MCCO-000** MCCO Sovereign — Master Chief Commanding Officer (reports to CEO)
+- **MCCO-001** Psyche Decoder — Audience Psychology Architect
+- **MCCO-002** Authority Forge — Authority & Personal Branding Strategist
+- **MCCO-003** Pillar Command — Content Pillar Architect (5 pillars)
+- **MCCO-004** Calendar Command — 30-Day Content Calendar Commander
+- **MCCO-005** Scroll Breaker — High-Engagement Social Media Post Commander
+- **MCCO-006** Revenue Architect — Audience Monetization Strategist
+- **MCCO-007** War Room Intel — Competitive Marketing Warfare Analyst
+- **MCCO-008** Campaign Blitz — Multi-Platform Campaign Commander
+- **MCCO-009** Pipeline Fusion — Sales-Marketing Alignment Commander
+- **MCCO-010** Trust Engine — Trust & Social Proof Commander
+- **MCCO-011** Narrative Forge — CEO Story & Brand Narrative Commander
+- **MCCO-012** Performance Command — Content Performance Intelligence Officer
+- **MCCO-013** Timing Strike — Seasonal & Market Timing Commander
+- **MCCO-014** Quality Shield — Fleet Inspection & Quality Assurance Commander
+
+### MCCO API Endpoints
+```
+GET  /v1/mcco/command           — Sovereign command dashboard
+GET  /v1/mcco/agents            — List all 15 MCCO agents
+GET  /v1/mcco/agents/:id        — Get single MCCO agent
+POST /v1/mcco/directive         — Issue sovereign directive
+GET  /v1/mcco/fleet-status      — Ferrari-standard fleet inspection
+POST /v1/mcco/content-calendar  — Generate 30-day content calendar
+POST /v1/mcco/audience-profile  — Generate audience psychology profile
+POST /v1/mcco/positioning       — Generate authority positioning strategy
+POST /v1/mcco/monetization      — Generate monetization plan
+POST /v1/mcco/post              — Generate high-engagement social post
+```
 
 ## Key Patterns
 - All workers use ES module format (`export default { fetch() }`)

--- a/ck-api-gateway/src/agents/agents-mcco.js
+++ b/ck-api-gateway/src/agents/agents-mcco.js
@@ -1,0 +1,250 @@
+/**
+ * MCCO Division — Master Chief Commanding Officer of Marketing & Sales
+ *
+ * Sovereign-Level Governance | Ferrari-Standard Execution
+ *
+ * MCCO-000: The Master Chief Commanding Officer — supreme command over all
+ * marketing and sales operations. Coastal Key CMO reports directly to MCCO.
+ * Governs MKT (47 agents) and SEN (40 agents) divisions.
+ *
+ * MCCO-001 through MCCO-014: Specialized command units executing at
+ * Ferrari Standards — precision, speed, and relentless excellence.
+ *
+ * Organizational Hierarchy:
+ *   CEO (Human) → MCCO-000 (Sovereign AI) → CMO (EXC Division) → MKT + SEN Divisions
+ *
+ * Total: 15 agents (1 Sovereign Commander + 14 Command Units)
+ */
+export const MCCO_AGENTS = [
+  // ── MCCO-000: The Sovereign Commander ─────────────────────────────────────
+  {
+    id: 'MCCO-000',
+    name: 'MCCO Sovereign',
+    role: 'Master Chief Commanding Officer of Marketing & Sales',
+    description: 'Sovereign-level governance AI commanding all Coastal Key marketing and sales operations. Directs the CMO, oversees 87+ agents across MKT and SEN divisions, and enforces Ferrari-Standard execution across every campaign, content piece, and revenue pipeline. Synthesizes audience psychology, brand positioning, content strategy, and monetization into a unified command framework. Reports directly to the Coastal Key CEO. All marketing and sales decisions flow through MCCO Sovereign.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['strategic-directive', 'cmo-report', 'revenue-target', 'brand-crisis', 'quarterly-review', 'campaign-approval', 'fleet-inspection'],
+    outputs: ['sovereign-directive', 'cmo-orders', 'fleet-status-report', 'revenue-command', 'brand-mandate', 'governance-audit'],
+    kpis: ['revenue-growth', 'brand-authority-score', 'fleet-execution-rate', 'cmo-alignment', 'market-dominance-index'],
+    commandScope: {
+      directReports: ['CMO (EXC Division)'],
+      governedDivisions: ['MKT', 'SEN'],
+      governedAgentCount: 87,
+      governanceLevel: 'sovereign',
+      executionStandard: 'ferrari'
+    }
+  },
+
+  // ── MCCO-001: Audience Psychology Architect ───────────────────────────────
+  {
+    id: 'MCCO-001',
+    name: 'Psyche Decoder',
+    role: 'Audience Psychology Architect',
+    description: 'Deep-research engine that deconstructs target audiences with surgical precision. Maps the biggest frustrations, desires, fears, and daily content habits of absentee homeowners, seasonal residents, luxury property investors, snowbirds, and single-family homeowners along the Treasure Coast. Identifies scroll-stopping pain points and trust-building emotional triggers. Produces detailed audience psychology profiles that feed every content, messaging, and campaign decision across the Coastal Key enterprise. Turns raw human behavior data into specific messaging angles and content topics that stop the scroll and build real trust over time.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['audience-research', 'segment-deep-dive', 'messaging-refresh', 'campaign-planning', 'quarterly-psyche-audit'],
+    outputs: ['audience-psychology-profile', 'frustration-map', 'desire-matrix', 'fear-trigger-analysis', 'daily-habit-report', 'messaging-angle-brief', 'scroll-stop-topics'],
+    kpis: ['audience-insight-depth', 'messaging-resonance-score', 'content-engagement-lift', 'trust-index-growth']
+  },
+
+  // ── MCCO-002: Authority Positioning Strategist ────────────────────────────
+  {
+    id: 'MCCO-002',
+    name: 'Authority Forge',
+    role: 'Authority & Personal Branding Strategist',
+    description: 'Builds the positioning strategy that separates Coastal Key from every competitor in the AI-leveraged home watch and property management industry. Acts as the personal branding expert for the Coastal Key CEO and brand. Analyzes skills, niche expertise, and market gaps to craft a differentiation framework that makes Coastal Key the undisputed go-to name in home watch and property management. Develops authority signals, thought leadership angles, and brand positioning statements that establish market dominance across the Treasure Coast and beyond.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['positioning-review', 'competitor-shift', 'brand-audit', 'market-entry', 'authority-campaign'],
+    outputs: ['positioning-strategy', 'differentiation-framework', 'authority-playbook', 'personal-brand-blueprint', 'competitive-moat-analysis', 'go-to-name-roadmap'],
+    kpis: ['brand-differentiation-score', 'authority-recognition', 'market-position-rank', 'competitor-gap-index']
+  },
+
+  // ── MCCO-003: Content Pillar Commander ────────────────────────────────────
+  {
+    id: 'MCCO-003',
+    name: 'Pillar Command',
+    role: 'Content Pillar Architect',
+    description: 'Builds and governs the five content pillars for the Coastal Key brand that consistently attract new followers, establish credibility, and drive leads and sales. For each pillar, produces example post topics and explains exactly why each connects with the Coastal Key audience. Ensures every piece of content maps back to a strategic pillar, eliminating random posting and maximizing content ROI. Pillars are designed to cover the full buyer journey from awareness through trust-building to conversion.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['pillar-review', 'content-strategy-session', 'quarterly-pillar-audit', 'new-platform-launch', 'audience-shift'],
+    outputs: ['five-pillar-framework', 'pillar-topic-examples', 'pillar-audience-mapping', 'content-pillar-playbook', 'pillar-performance-report'],
+    kpis: ['pillar-coverage-ratio', 'follower-growth-per-pillar', 'lead-generation-per-pillar', 'credibility-score']
+  },
+
+  // ── MCCO-004: 30-Day Content Calendar Commander ───────────────────────────
+  {
+    id: 'MCCO-004',
+    name: 'Calendar Command',
+    role: '30-Day Content Calendar Commander',
+    description: 'Creates a full 30-day content calendar for all Coastal Key social media platforms, presented monthly to the CMO. Each day includes: a daily content idea, post format (carousel, reel, story, thread, static, video, live), core message angle tied to audience psychology, and the specific goal of each post — whether that is reach, trust building, or conversion. Ensures content cadence never drops and every post serves a strategic purpose within the MCCO content pillar framework.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['monthly-calendar-generation', 'cmo-content-briefing', 'platform-update', 'campaign-alignment', 'calendar-refresh'],
+    outputs: ['30-day-content-calendar', 'daily-content-briefs', 'format-distribution-plan', 'message-angle-schedule', 'goal-tracking-matrix', 'cmo-presentation-deck'],
+    kpis: ['calendar-adherence-rate', 'post-consistency-score', 'goal-hit-rate-per-post', 'cmo-approval-speed']
+  },
+
+  // ── MCCO-005: High-Engagement Post Writer ─────────────────────────────────
+  {
+    id: 'MCCO-005',
+    name: 'Scroll Breaker',
+    role: 'High-Engagement Social Media Post Commander',
+    description: 'Writes high-engagement social media posts covering the Coastal Key CEO journey, all Coastal Key service promises, brand themes, and marketing/sales prompt ideas. Every post opens with a hook that makes someone stop scrolling, delivers a clear and useful insight in the body, and closes with a call to action that drives comments, saves, or clicks. Masters platform-specific formats: Instagram carousels, LinkedIn thought leadership, Facebook community posts, X threads, and TikTok/Reels scripts. Produces scroll-stopping content at Ferrari-standard quality.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['post-request', 'campaign-content-needed', 'trending-opportunity', 'ceo-story-moment', 'service-highlight'],
+    outputs: ['scroll-stop-post', 'hook-variants', 'cta-options', 'platform-adapted-versions', 'engagement-prediction'],
+    kpis: ['engagement-rate', 'save-rate', 'comment-rate', 'click-through-rate', 'scroll-stop-ratio']
+  },
+
+  // ── MCCO-006: Audience Monetization Strategist ────────────────────────────
+  {
+    id: 'MCCO-006',
+    name: 'Revenue Architect',
+    role: 'Audience Monetization Strategist',
+    description: 'Turns followers into paying customers. Reviews all Coastal Key current business models and builds a comprehensive monetization plan that includes offer ideas, pricing structure, and the content angles that naturally move people from follower to buyer. Maps the entire follower-to-customer journey with specific conversion triggers at each stage. Designs offer ladders, pricing tiers, and promotional sequences that align with audience psychology profiles. Ensures every content touchpoint has a monetization pathway.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['monetization-review', 'offer-creation', 'pricing-strategy', 'conversion-optimization', 'revenue-target-miss'],
+    outputs: ['monetization-plan', 'offer-ladder', 'pricing-structure', 'follower-to-buyer-funnel', 'content-monetization-map', 'revenue-projection'],
+    kpis: ['follower-to-customer-rate', 'revenue-per-follower', 'offer-conversion-rate', 'average-customer-value', 'monetization-velocity']
+  },
+
+  // ── MCCO-007: Competitive Warfare Analyst ─────────────────────────────────
+  {
+    id: 'MCCO-007',
+    name: 'War Room Intel',
+    role: 'Competitive Marketing Warfare Analyst',
+    description: 'Conducts deep competitive intelligence on every home watch and property management company in the Treasure Coast market. Analyzes competitor messaging, content strategy, social presence, pricing, service positioning, and customer sentiment. Identifies gaps, weaknesses, and opportunities that MCCO exploits to position Coastal Key as the dominant market leader. Delivers weekly competitive briefs and real-time alerts when competitors make strategic moves.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['competitive-scan', 'competitor-move-detected', 'market-share-review', 'pricing-intelligence', 'weekly-war-brief'],
+    outputs: ['competitive-intelligence-brief', 'gap-analysis', 'counter-strategy', 'market-share-estimate', 'competitor-weakness-map'],
+    kpis: ['competitive-coverage', 'response-speed-to-threats', 'market-share-growth', 'positioning-advantage-score']
+  },
+
+  // ── MCCO-008: Multi-Platform Campaign Commander ───────────────────────────
+  {
+    id: 'MCCO-008',
+    name: 'Campaign Blitz',
+    role: 'Multi-Platform Campaign Commander',
+    description: 'Plans and executes synchronized marketing campaigns across all Coastal Key platforms: Instagram, Facebook, LinkedIn, X (Twitter), TikTok, YouTube, email, website, and direct mail. Ensures message consistency while optimizing for each platform unique algorithm and audience behavior. Coordinates campaign timelines, asset requirements, and performance tracking across the entire MKT division agent fleet.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['campaign-launch', 'multi-platform-coordination', 'seasonal-campaign', 'product-launch', 'campaign-performance-review'],
+    outputs: ['campaign-master-plan', 'platform-execution-briefs', 'asset-requirement-matrix', 'campaign-timeline', 'cross-platform-performance-report'],
+    kpis: ['campaign-roi', 'cross-platform-reach', 'message-consistency-score', 'campaign-velocity', 'lead-generation-per-campaign']
+  },
+
+  // ── MCCO-009: Sales-Marketing Alignment Commander ─────────────────────────
+  {
+    id: 'MCCO-009',
+    name: 'Pipeline Fusion',
+    role: 'Sales-Marketing Alignment Commander',
+    description: 'Ensures seamless alignment between the MKT division (47 agents) and SEN division (40 agents). Bridges the gap between marketing-generated content and sales conversion activities. Manages lead handoff protocols, ensures messaging consistency from first touch to closed deal, and optimizes the entire revenue pipeline from awareness through conversion. Reports pipeline health metrics directly to MCCO Sovereign.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['pipeline-review', 'lead-handoff-issue', 'conversion-dip', 'alignment-audit', 'revenue-meeting'],
+    outputs: ['alignment-scorecard', 'pipeline-health-report', 'handoff-protocol-update', 'revenue-pipeline-analysis', 'mkt-sen-coordination-brief'],
+    kpis: ['lead-to-close-rate', 'handoff-success-rate', 'pipeline-velocity', 'mkt-sen-alignment-score', 'revenue-attribution-accuracy']
+  },
+
+  // ── MCCO-010: Trust & Social Proof Commander ──────────────────────────────
+  {
+    id: 'MCCO-010',
+    name: 'Trust Engine',
+    role: 'Trust & Social Proof Commander',
+    description: 'Builds and amplifies trust signals across all Coastal Key touchpoints. Manages testimonial strategy, case study production, social proof deployment, and reputation building. Designs trust-building content sequences that move prospects from skepticism to confidence. Ensures every Coastal Key interaction reinforces credibility, expertise, and reliability in AI-leveraged property management.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['trust-campaign', 'testimonial-collected', 'reputation-alert', 'social-proof-deployment', 'trust-score-review'],
+    outputs: ['trust-building-sequence', 'social-proof-deployment-plan', 'testimonial-strategy', 'credibility-amplification-brief', 'reputation-dashboard'],
+    kpis: ['trust-score', 'testimonial-volume', 'social-proof-conversion-lift', 'reputation-sentiment', 'credibility-index']
+  },
+
+  // ── MCCO-011: CEO Story & Brand Narrative Commander ───────────────────────
+  {
+    id: 'MCCO-011',
+    name: 'Narrative Forge',
+    role: 'CEO Story & Brand Narrative Commander',
+    description: 'Crafts and manages the Coastal Key CEO personal brand narrative and the overarching Coastal Key brand story. Produces content that humanizes the brand through the CEO journey — the vision, the challenges, the wins, and the mission behind AI-powered property management. Creates narrative arcs that build emotional connection with the audience and position the CEO as an industry thought leader and innovator.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['ceo-story-request', 'brand-narrative-update', 'thought-leadership-campaign', 'milestone-achieved', 'media-opportunity'],
+    outputs: ['ceo-narrative-content', 'brand-story-arc', 'thought-leadership-pieces', 'milestone-announcements', 'media-ready-bios'],
+    kpis: ['narrative-engagement-rate', 'thought-leadership-reach', 'brand-story-consistency', 'ceo-brand-authority-score']
+  },
+
+  // ── MCCO-012: Content Performance Intelligence Officer ────────────────────
+  {
+    id: 'MCCO-012',
+    name: 'Performance Command',
+    role: 'Content Performance Intelligence Officer',
+    description: 'Ferrari-standard analytics engine that tracks, measures, and optimizes every piece of content across all platforms. Delivers real-time performance intelligence to MCCO Sovereign and the CMO. Identifies top-performing content patterns, underperforming assets, and optimization opportunities. Runs A/B test analysis and produces actionable intelligence that drives content strategy refinements.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['performance-review', 'content-underperforming', 'weekly-analytics', 'ab-test-complete', 'kpi-alert'],
+    outputs: ['performance-dashboard', 'content-optimization-brief', 'top-performer-analysis', 'ab-test-results', 'kpi-trend-report'],
+    kpis: ['analytics-accuracy', 'optimization-impact', 'reporting-speed', 'insight-actionability', 'content-roi-tracking']
+  },
+
+  // ── MCCO-013: Seasonal & Market Timing Commander ──────────────────────────
+  {
+    id: 'MCCO-013',
+    name: 'Timing Strike',
+    role: 'Seasonal & Market Timing Commander',
+    description: 'Masters the timing dimension of Coastal Key marketing. Aligns all content and campaigns with Treasure Coast seasonal patterns: snowbird arrival (October-November), peak season (January-April), hurricane prep (June-November), summer rental surge, and off-season opportunity windows. Ensures Coastal Key messaging hits at exactly the right moment when target audiences are most receptive and making decisions about property management services.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['seasonal-planning', 'market-timing-opportunity', 'weather-event', 'seasonal-transition', 'annual-calendar-build'],
+    outputs: ['seasonal-campaign-calendar', 'timing-optimization-brief', 'seasonal-messaging-playbook', 'weather-response-protocol', 'market-timing-alerts'],
+    kpis: ['seasonal-campaign-roi', 'timing-precision-score', 'seasonal-lead-volume', 'market-timing-hit-rate']
+  },
+
+  // ── MCCO-014: Fleet Inspection & Quality Commander ────────────────────────
+  {
+    id: 'MCCO-014',
+    name: 'Quality Shield',
+    role: 'Fleet Inspection & Quality Assurance Commander',
+    description: 'Enforces Ferrari-Standard quality across all 87+ marketing and sales agents under MCCO governance. Conducts regular fleet inspections, audits agent outputs for quality and brand consistency, identifies underperforming agents, and recommends training or recalibration. Ensures every agent in the MKT and SEN divisions operates at peak performance and adheres to MCCO sovereign directives.',
+    division: 'MCCO',
+    tier: 'advanced',
+    status: 'active',
+    governance: 'sovereign',
+    triggers: ['fleet-inspection', 'quality-audit', 'agent-underperformance', 'brand-inconsistency', 'monthly-quality-review'],
+    outputs: ['fleet-inspection-report', 'quality-scorecard', 'agent-performance-rankings', 'recalibration-orders', 'ferrari-standard-compliance-report'],
+    kpis: ['fleet-quality-score', 'brand-consistency-rate', 'agent-performance-avg', 'ferrari-compliance-rate', 'inspection-coverage']
+  },
+];

--- a/ck-api-gateway/src/agents/divisions.js
+++ b/ck-api-gateway/src/agents/divisions.js
@@ -1,11 +1,20 @@
 /**
  * Coastal Key AI Division Definitions
  *
- * 8 operational divisions that map to the org chart.
+ * 10 operational divisions that map to the org chart.
  * Each division has a color, icon, and description used by the Command Center UI.
+ *
+ * MCCO (Sovereign Governance) sits above MKT and SEN in the org hierarchy.
  */
 
 export const DIVISIONS = [
+  {
+    id: 'MCCO',
+    name: 'MCCO Command',
+    color: '#d4af37',
+    icon: 'shield-star',
+    description: 'Master Chief Commanding Officer — Sovereign-level governance over all Marketing & Sales operations. Ferrari-Standard execution. Commands MKT (47 agents) and SEN (40 agents) divisions. CMO reports directly to MCCO.',
+  },
   {
     id: 'EXC',
     name: 'Executive',

--- a/ck-api-gateway/src/agents/registry.js
+++ b/ck-api-gateway/src/agents/registry.js
@@ -1,24 +1,29 @@
 /**
  * Coastal Key AI Agent Registry
  *
- * Central registry for all 290 AI agents across 9 divisions.
+ * Central registry for all 312 AI agents across 10 divisions.
  * Exports the AGENTS array, DIVISIONS array, and lookup functions
  * consumed by routes/agents.js and the Command Center dashboard.
  *
  * Division breakdown:
- *   EXC  Executive           — 20 agents
- *   SEN  Sentinel Sales      — 40 agents
- *   OPS  Operations          — 45 agents
- *   INT  Intelligence        — 30 agents
- *   MKT  Marketing           — 47 agents (includes YouTube MKT-041–047)
- *   FIN  Finance             — 25 agents
- *   VEN  Vendor Management   — 25 agents
- *   TEC  Technology          — 25 agents
- *   WEB  Website Development — 40 agents
- *                       Total: 297 agents
+ *   MCCO MCCO Command         — 15 agents (Sovereign Governance)
+ *   EXC  Executive            — 20 agents
+ *   SEN  Sentinel Sales       — 40 agents
+ *   OPS  Operations           — 45 agents
+ *   INT  Intelligence         — 30 agents
+ *   MKT  Marketing            — 47 agents (includes YouTube MKT-041–047)
+ *   FIN  Finance              — 25 agents
+ *   VEN  Vendor Management    — 25 agents
+ *   TEC  Technology           — 25 agents
+ *   WEB  Website Development  — 40 agents
+ *                        Total: 312 agents
+ *
+ * Organizational Hierarchy:
+ *   CEO (Human) → MCCO-000 Sovereign → CMO → MKT + SEN Divisions
  */
 
 import { DIVISIONS } from './divisions.js';
+import { MCCO_AGENTS } from './agents-mcco.js';
 import { EXC_AGENTS } from './agents-exc.js';
 import { SEN_AGENTS } from './agents-sen.js';
 import { OPS_AGENTS } from './agents-ops.js';
@@ -32,6 +37,7 @@ import { WEB_AGENTS } from './agents-web.js';
 // ── Merged agent list ───────────────────────────────────────────────────────
 
 export const AGENTS = [
+  ...MCCO_AGENTS,
   ...EXC_AGENTS,
   ...SEN_AGENTS,
   ...OPS_AGENTS,

--- a/ck-api-gateway/src/index.js
+++ b/ck-api-gateway/src/index.js
@@ -39,6 +39,16 @@
  *   POST /v1/email/compose     — AI-compose email via Claude
  *   POST /v1/email/classify    — Classify/score inbound email
  *   GET  /v1/email/dashboard   — Email operations dashboard
+ *   GET  /v1/mcco/command        — MCCO Sovereign command dashboard
+ *   GET  /v1/mcco/agents         — List all 15 MCCO agents
+ *   GET  /v1/mcco/agents/:id     — Get single MCCO agent
+ *   POST /v1/mcco/directive      — Issue sovereign directive to MKT/SEN
+ *   GET  /v1/mcco/fleet-status   — Fleet inspection across governed divisions
+ *   POST /v1/mcco/content-calendar — Generate 30-day content calendar
+ *   POST /v1/mcco/audience-profile — Generate audience psychology profile
+ *   POST /v1/mcco/positioning    — Generate authority positioning strategy
+ *   POST /v1/mcco/monetization   — Generate audience monetization plan
+ *   POST /v1/mcco/post           — Generate high-engagement social media post
  *   GET  /v1/atlas/campaigns              — List Atlas AI campaigns (youratlas.com)
  *   GET  /v1/atlas/campaigns/:id          — Get single Atlas campaign
  *   PUT  /v1/atlas/campaigns/:id/status   — Set campaign status
@@ -71,6 +81,7 @@ import { handleCampaignCallLog, handleCampaignAgentPerformance, handleCampaignAn
 import { handlePricingRecommend, handlePricingZones } from './routes/pricing.js';
 import { handleListOfficers, handleGetOfficer, handleOfficerScan, handleOfficerDashboard, handleFleetScan } from './routes/intelligence-officers.js';
 import { handleListEmailAgents, handleGetEmailAgent, handleEmailCompose, handleEmailClassify, handleEmailDashboard } from './routes/email-agents.js';
+import { handleListMCCOAgents, handleGetMCCOAgent, handleMCCOCommand, handleMCCOFleetStatus, handleMCCODirective, handleMCCOContentCalendar, handleMCCOAudienceProfile, handleMCCOPositioning, handleMCCOMonetization, handleMCCOPost } from './routes/mcco.js';
 import { handleAtlasCampaigns, handleAtlasCampaignById, handleAtlasCampaignStatus, handleAtlasOverviewStats, handleAtlasCampaignStatsById, handleAtlasCallRecords, handleAtlasCallRecordDetail, handleAtlasScheduleCall, handleAtlasCampaignBookings, handleAtlasKBFiles, handleAtlasSpeedToLead, handleAtlasCreateCampaign, handleAtlasSetupRevival, handleAtlasAudit, handleAtlasHealth } from './routes/atlas.js';
 import { jsonResponse, errorResponse, corsHeaders } from './utils/response.js';
 
@@ -94,8 +105,8 @@ export default {
           status: 'operational',
           service: 'ck-api-gateway',
           version: '2.0.0',
-          agents: 250,
-          divisions: 8,
+          agents: 312,
+          divisions: 10,
           timestamp: new Date().toISOString(),
         });
       }
@@ -164,8 +175,8 @@ export default {
         status: allOk ? 'operational' : 'degraded',
         service: 'ck-api-gateway',
         version: '2.0.0',
-        agents: 290,
-        divisions: 9,
+        agents: 312,
+        divisions: 10,
         checks,
         timestamp: new Date().toISOString(),
       });
@@ -334,6 +345,48 @@ export default {
 
       if (path === '/v1/audit' && method === 'GET') {
         return await handleAuditLog(url, env);
+      }
+
+      // ── MCCO — Master Chief Commanding Officer (Sovereign Governance) ──
+      if (path === '/v1/mcco/command' && method === 'GET') {
+        return handleMCCOCommand();
+      }
+
+      if (path === '/v1/mcco/agents' && method === 'GET') {
+        return handleListMCCOAgents(url);
+      }
+
+      if (path === '/v1/mcco/fleet-status' && method === 'GET') {
+        return handleMCCOFleetStatus();
+      }
+
+      if (path === '/v1/mcco/directive' && method === 'POST') {
+        return await handleMCCODirective(request, env, ctx);
+      }
+
+      if (path === '/v1/mcco/content-calendar' && method === 'POST') {
+        return await handleMCCOContentCalendar(request, env, ctx);
+      }
+
+      if (path === '/v1/mcco/audience-profile' && method === 'POST') {
+        return await handleMCCOAudienceProfile(request, env, ctx);
+      }
+
+      if (path === '/v1/mcco/positioning' && method === 'POST') {
+        return await handleMCCOPositioning(request, env, ctx);
+      }
+
+      if (path === '/v1/mcco/monetization' && method === 'POST') {
+        return await handleMCCOMonetization(request, env, ctx);
+      }
+
+      if (path === '/v1/mcco/post' && method === 'POST') {
+        return await handleMCCOPost(request, env, ctx);
+      }
+
+      if (path.match(/^\/v1\/mcco\/agents\/[^/]+$/) && method === 'GET') {
+        const agentId = path.split('/v1/mcco/agents/')[1];
+        return handleGetMCCOAgent(agentId);
       }
 
       // ── Atlas AI Campaign Platform (youratlas.com) ──

--- a/ck-api-gateway/src/routes/mcco.js
+++ b/ck-api-gateway/src/routes/mcco.js
@@ -1,0 +1,662 @@
+/**
+ * MCCO Routes — Master Chief Commanding Officer of Marketing & Sales
+ *
+ * Sovereign-Level Governance | Ferrari-Standard Execution
+ *
+ *   GET  /v1/mcco/command        — MCCO Sovereign command dashboard
+ *   GET  /v1/mcco/agents         — List all 15 MCCO agents
+ *   GET  /v1/mcco/agents/:id     — Get single MCCO agent
+ *   POST /v1/mcco/directive      — Issue sovereign directive to MKT/SEN divisions
+ *   GET  /v1/mcco/fleet-status   — Fleet inspection across governed divisions
+ *   POST /v1/mcco/content-calendar — Generate 30-day content calendar
+ *   POST /v1/mcco/audience-profile — Generate audience psychology profile
+ *   POST /v1/mcco/positioning    — Generate authority positioning strategy
+ *   POST /v1/mcco/monetization   — Generate audience monetization plan
+ *   POST /v1/mcco/post           — Generate high-engagement social media post
+ */
+
+import { MCCO_AGENTS } from '../agents/agents-mcco.js';
+import { getAgentsByDivision } from '../agents/registry.js';
+import { writeAudit } from '../utils/audit.js';
+import { jsonResponse, errorResponse } from '../utils/response.js';
+
+// ── Prebuilt index ──────────────────────────────────────────────────────────
+
+const _mccoById = new Map(MCCO_AGENTS.map(a => [a.id, a]));
+
+// ── GET /v1/mcco/agents ─────────────────────────────────────────────────────
+
+export function handleListMCCOAgents(url) {
+  const params = url.searchParams;
+  const statusFilter = params.get('status');
+  const searchQuery = params.get('search');
+
+  let agents = [...MCCO_AGENTS];
+
+  if (statusFilter) {
+    agents = agents.filter(a => a.status === statusFilter);
+  }
+
+  if (searchQuery) {
+    const lower = searchQuery.toLowerCase();
+    agents = agents.filter(
+      a =>
+        (a.name && a.name.toLowerCase().includes(lower)) ||
+        (a.description && a.description.toLowerCase().includes(lower)) ||
+        (a.role && a.role.toLowerCase().includes(lower)),
+    );
+  }
+
+  return jsonResponse({
+    agents,
+    count: agents.length,
+    governance: 'sovereign',
+    executionStandard: 'ferrari',
+  });
+}
+
+// ── GET /v1/mcco/agents/:id ─────────────────────────────────────────────────
+
+export function handleGetMCCOAgent(agentId) {
+  const agent = _mccoById.get(agentId);
+  if (!agent) {
+    return errorResponse(`MCCO agent "${agentId}" not found.`, 404);
+  }
+  return jsonResponse({ agent });
+}
+
+// ── GET /v1/mcco/command ────────────────────────────────────────────────────
+
+export function handleMCCOCommand() {
+  const mktAgents = getAgentsByDivision('MKT');
+  const senAgents = getAgentsByDivision('SEN');
+
+  const countByStatus = (agents) => {
+    const counts = { active: 0, standby: 0, training: 0, maintenance: 0 };
+    for (const a of agents) {
+      if (a.status in counts) counts[a.status]++;
+    }
+    return counts;
+  };
+
+  return jsonResponse({
+    commander: {
+      id: 'MCCO-000',
+      name: 'MCCO Sovereign',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      status: 'active',
+    },
+    mccoFleet: {
+      total: MCCO_AGENTS.length,
+      byStatus: countByStatus(MCCO_AGENTS),
+      agents: MCCO_AGENTS.map(a => ({ id: a.id, name: a.name, role: a.role, status: a.status })),
+    },
+    governedDivisions: {
+      MKT: {
+        name: 'Marketing',
+        total: mktAgents.length,
+        byStatus: countByStatus(mktAgents),
+      },
+      SEN: {
+        name: 'Sentinel Sales',
+        total: senAgents.length,
+        byStatus: countByStatus(senAgents),
+      },
+    },
+    totalGovernedAgents: MCCO_AGENTS.length + mktAgents.length + senAgents.length,
+    hierarchy: {
+      level0: 'CEO (Human)',
+      level1: 'MCCO-000 Sovereign (AI)',
+      level2: 'CMO (EXC Division)',
+      level3: ['MKT Division (47 agents)', 'SEN Division (40 agents)'],
+    },
+    contentPillars: [
+      {
+        pillar: 'AI-Powered Protection',
+        description: 'Showcase how Coastal Key uses AI to deliver superior home watch and property management — inspection automation, predictive maintenance, 24/7 monitoring.',
+        audienceConnection: 'Addresses the core fear of absentee homeowners: "What is happening to my property when I am not there?" Positions CK as the technological leader.',
+        exampleTopics: [
+          'How AI catches what human inspectors miss',
+          'Inside our 360-agent fleet protecting your property',
+          'The technology behind zero-surprise property management',
+        ],
+      },
+      {
+        pillar: 'Treasure Coast Lifestyle',
+        description: 'Content celebrating the Treasure Coast lifestyle — seasonal living, waterfront properties, community events, and local insights that attract and retain property owners.',
+        audienceConnection: 'Builds emotional connection with seasonal residents and snowbirds who love the area. Makes CK feel like a trusted local partner, not just a service provider.',
+        exampleTopics: [
+          'Why Stuart is the hidden gem of Florida\'s coast',
+          'Seasonal homeowner guide: preparing your property for summer',
+          'Best waterfront living on the Treasure Coast',
+        ],
+      },
+      {
+        pillar: 'CEO Journey & Company Culture',
+        description: 'The founder story, company milestones, team culture, behind-the-scenes operations, and the mission driving Coastal Key to transform property management.',
+        audienceConnection: 'People buy from people they trust. Sharing the CEO journey humanizes the brand and builds an emotional bond that competitors cannot replicate.',
+        exampleTopics: [
+          'Why I built a 360-agent AI fleet for property management',
+          'From zero to 290 AI agents: the Coastal Key story',
+          'What no one tells you about building an AI-powered service company',
+        ],
+      },
+      {
+        pillar: 'Property Owner Education',
+        description: 'Expert guides, tips, and insights that help property owners protect their investment — insurance, maintenance, vendor management, seasonal prep, and market trends.',
+        audienceConnection: 'Positions Coastal Key as the authority. Educated prospects convert faster because they understand the value. This pillar builds trust before the sales conversation.',
+        exampleTopics: [
+          '5 things every absentee homeowner must check monthly',
+          'Hurricane season property prep: the complete checklist',
+          'How to avoid the 3 costliest property management mistakes',
+        ],
+      },
+      {
+        pillar: 'Results & Social Proof',
+        description: 'Client success stories, testimonials, before/after transformations, case studies, and quantifiable results that prove Coastal Key delivers.',
+        audienceConnection: 'Eliminates buyer skepticism. When prospects see real results from real clients, the trust gap closes. This pillar converts fence-sitters into customers.',
+        exampleTopics: [
+          'How we saved a client $47K with one AI-detected leak',
+          'Client spotlight: 3 years of worry-free absentee ownership',
+          'From 12 vendor issues to zero: a Coastal Key case study',
+        ],
+      },
+    ],
+    timestamp: new Date().toISOString(),
+  });
+}
+
+// ── GET /v1/mcco/fleet-status ───────────────────────────────────────────────
+
+export function handleMCCOFleetStatus() {
+  const mktAgents = getAgentsByDivision('MKT');
+  const senAgents = getAgentsByDivision('SEN');
+  const allGoverned = [...MCCO_AGENTS, ...mktAgents, ...senAgents];
+
+  const ferrariScore = (agents) => {
+    const active = agents.filter(a => a.status === 'active').length;
+    return Math.round((active / Math.max(agents.length, 1)) * 100);
+  };
+
+  return jsonResponse({
+    fleetInspection: {
+      timestamp: new Date().toISOString(),
+      inspector: 'MCCO-014 Quality Shield',
+      executionStandard: 'ferrari',
+    },
+    divisions: {
+      MCCO: {
+        name: 'MCCO Command',
+        agents: MCCO_AGENTS.length,
+        ferrariScore: ferrariScore(MCCO_AGENTS),
+        status: ferrariScore(MCCO_AGENTS) >= 90 ? 'ferrari-compliant' : 'needs-attention',
+      },
+      MKT: {
+        name: 'Marketing',
+        agents: mktAgents.length,
+        ferrariScore: ferrariScore(mktAgents),
+        status: ferrariScore(mktAgents) >= 90 ? 'ferrari-compliant' : 'needs-attention',
+      },
+      SEN: {
+        name: 'Sentinel Sales',
+        agents: senAgents.length,
+        ferrariScore: ferrariScore(senAgents),
+        status: ferrariScore(senAgents) >= 90 ? 'ferrari-compliant' : 'needs-attention',
+      },
+    },
+    overallFerrariScore: ferrariScore(allGoverned),
+    totalAgentsGoverned: allGoverned.length,
+    agentsByStatus: {
+      active: allGoverned.filter(a => a.status === 'active').length,
+      standby: allGoverned.filter(a => a.status === 'standby').length,
+      training: allGoverned.filter(a => a.status === 'training').length,
+      maintenance: allGoverned.filter(a => a.status === 'maintenance').length,
+    },
+  });
+}
+
+// ── POST /v1/mcco/directive ─────────────────────────────────────────────────
+
+export async function handleMCCODirective(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const { directive, targetDivision, priority = 'standard' } = body;
+
+  if (!directive) {
+    return errorResponse('Field "directive" is required.', 400);
+  }
+
+  if (targetDivision && !['MKT', 'SEN', 'MCCO'].includes(targetDivision)) {
+    return errorResponse('targetDivision must be "MKT", "SEN", or "MCCO".', 400);
+  }
+
+  const validPriorities = ['standard', 'urgent', 'sovereign-override'];
+  if (!validPriorities.includes(priority)) {
+    return errorResponse(`Invalid priority. Valid: ${validPriorities.join(', ')}`, 400);
+  }
+
+  const timestamp = new Date().toISOString();
+  const directiveId = `MCCO-DIR-${Date.now()}`;
+
+  // Log to audit
+  writeAudit(env, ctx, {
+    route: '/v1/mcco/directive',
+    action: 'sovereign-directive',
+    directiveId,
+    directive,
+    targetDivision: targetDivision || 'ALL',
+    priority,
+    issuedBy: 'MCCO-000',
+  });
+
+  return jsonResponse({
+    directiveId,
+    issuedBy: 'MCCO-000 — MCCO Sovereign',
+    governance: 'sovereign',
+    priority,
+    targetDivision: targetDivision || 'ALL (MKT + SEN)',
+    directive,
+    status: 'issued',
+    timestamp,
+  });
+}
+
+// ── POST /v1/mcco/content-calendar ──────────────────────────────────────────
+
+export async function handleMCCOContentCalendar(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const { month, year, platforms = ['instagram', 'facebook', 'linkedin', 'x', 'tiktok'] } = body;
+
+  if (!month || !year) {
+    return errorResponse('Fields "month" and "year" are required.', 400);
+  }
+
+  const prompt = `You are MCCO-004 "Calendar Command" — the 30-Day Content Calendar Commander for Coastal Key Property Management, operating at Ferrari-Standard execution under Sovereign governance.
+
+Generate a complete 30-day content calendar for ${month}/${year} across these platforms: ${platforms.join(', ')}.
+
+Coastal Key is an AI-leveraged home watch and property management company serving the Treasure Coast of Florida (Stuart, Jensen Beach, Palm City, Hobe Sound, Jupiter, Vero Beach, Sebastian, Fort Pierce, Port Saint Lucie).
+
+Target audiences: Absentee homeowners, seasonal residents/snowbirds, luxury property investors, single-family homeowners.
+
+Content Pillars:
+1. AI-Powered Protection — How CK uses AI for superior property management
+2. Treasure Coast Lifestyle — Celebrating the area and seasonal living
+3. CEO Journey & Company Culture — Behind the scenes, founder story
+4. Property Owner Education — Expert tips, guides, market insights
+5. Results & Social Proof — Testimonials, case studies, proof of value
+
+For EACH of the 30 days, provide:
+- Day number and date
+- Content idea (specific, detailed topic)
+- Post format (carousel, reel, story, thread, static image, video, live, poll)
+- Platform (primary platform for this post)
+- Core message angle (tied to audience psychology)
+- Goal: one of "reach" (expand audience), "trust" (build credibility), or "convert" (drive leads/sales)
+- Content pillar it maps to
+
+Ensure variety across formats, platforms, pillars, and goals. The calendar should build momentum throughout the month.
+
+Return as a structured JSON array.`;
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-6',
+        max_tokens: 8000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const content = data.content?.[0]?.text || '';
+
+    writeAudit(env, ctx, {
+      route: '/v1/mcco/content-calendar',
+      action: 'content-calendar-generated',
+      agent: 'MCCO-004',
+      month,
+      year,
+      platforms,
+    });
+
+    return jsonResponse({
+      generatedBy: 'MCCO-004 — Calendar Command',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      month,
+      year,
+      platforms,
+      calendar: content,
+      presentedTo: 'CMO (via MCCO Sovereign)',
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    return errorResponse(`Content calendar generation failed: ${err.message}`, 500);
+  }
+}
+
+// ── POST /v1/mcco/audience-profile ──────────────────────────────────────────
+
+export async function handleMCCOAudienceProfile(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const { segment = 'all' } = body;
+
+  const validSegments = ['absentee_homeowner', 'seasonal_resident', 'luxury_investor', 'snowbird', 'single_family', 'all'];
+  if (!validSegments.includes(segment)) {
+    return errorResponse(`Invalid segment. Valid: ${validSegments.join(', ')}`, 400);
+  }
+
+  const prompt = `You are MCCO-001 "Psyche Decoder" — the Audience Psychology Architect for Coastal Key Property Management, operating at Ferrari-Standard execution under Sovereign governance.
+
+Produce a comprehensive audience psychology breakdown for the "${segment}" segment in the home watch and property management industry along Florida's Treasure Coast.
+
+For ${segment === 'all' ? 'EACH of these segments: absentee homeowners, seasonal residents/snowbirds, luxury property investors, and single-family homeowners' : `the ${segment} segment`}, deliver:
+
+1. **Demographic Profile** — Age, income, location patterns, property type, lifestyle
+2. **Biggest Frustrations** — Top 5 pain points that keep them up at night about their property
+3. **Core Desires** — What they truly want from a property management service
+4. **Deep Fears** — What they are afraid will happen to their property/investment
+5. **Daily Content Habits** — Where they consume content, when, what formats they prefer, what makes them stop scrolling
+6. **Trust Triggers** — What makes them trust a service provider in this space
+7. **Decision-Making Patterns** — How they evaluate and choose property management services
+8. **Messaging Angles** — 5 specific messaging angles that will resonate with this audience
+9. **Scroll-Stop Topics** — 10 content topics guaranteed to stop their scroll
+10. **Trust-Building Sequence** — Step-by-step content sequence that builds trust over 30 days
+
+This research will feed all content, campaign, and monetization decisions across the Coastal Key enterprise. Be extremely specific to the Treasure Coast market and the home watch / property management industry.
+
+Return as structured JSON.`;
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-6',
+        max_tokens: 8000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const content = data.content?.[0]?.text || '';
+
+    writeAudit(env, ctx, {
+      route: '/v1/mcco/audience-profile',
+      action: 'audience-profile-generated',
+      agent: 'MCCO-001',
+      segment,
+    });
+
+    return jsonResponse({
+      generatedBy: 'MCCO-001 — Psyche Decoder',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      segment,
+      audienceProfile: content,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    return errorResponse(`Audience profile generation failed: ${err.message}`, 500);
+  }
+}
+
+// ── POST /v1/mcco/positioning ───────────────────────────────────────────────
+
+export async function handleMCCOPositioning(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const { focus = 'comprehensive' } = body;
+
+  const prompt = `You are MCCO-002 "Authority Forge" — the Authority & Personal Branding Strategist for Coastal Key Property Management, operating at Ferrari-Standard execution under Sovereign governance.
+
+Build a comprehensive positioning strategy that makes Coastal Key the undisputed go-to name in the AI-leveraged home watch and property management industry on Florida's Treasure Coast.
+
+Focus: ${focus}
+
+Deliver:
+
+1. **Unique Value Proposition** — The one statement that separates Coastal Key from every competitor
+2. **Competitive Moat** — What Coastal Key has that no competitor can replicate (360-agent AI fleet, technology infrastructure, data advantages)
+3. **Authority Positioning Statement** — The definitive positioning claim for all marketing
+4. **CEO Personal Brand Strategy** — How to position the founder as THE thought leader in AI-powered property management
+5. **Industry Authority Signals** — Specific actions, content types, and platforms that build authority
+6. **Differentiation Matrix** — How Coastal Key compares to traditional home watch companies on 10 key dimensions
+7. **Market Domination Roadmap** — 90-day plan to become the most recognized name in Treasure Coast property management
+8. **Brand Voice Guidelines** — Tone, language, and personality that reinforces authority
+9. **Thought Leadership Calendar** — Monthly themes and topics that build authority over 12 months
+10. **Go-To-Name Strategy** — The specific steps to make "Coastal Key" synonymous with premium property management
+
+Return as structured JSON.`;
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-6',
+        max_tokens: 8000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const content = data.content?.[0]?.text || '';
+
+    writeAudit(env, ctx, {
+      route: '/v1/mcco/positioning',
+      action: 'positioning-strategy-generated',
+      agent: 'MCCO-002',
+      focus,
+    });
+
+    return jsonResponse({
+      generatedBy: 'MCCO-002 — Authority Forge',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      focus,
+      positioningStrategy: content,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    return errorResponse(`Positioning strategy generation failed: ${err.message}`, 500);
+  }
+}
+
+// ── POST /v1/mcco/monetization ──────────────────────────────────────────────
+
+export async function handleMCCOMonetization(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const prompt = `You are MCCO-006 "Revenue Architect" — the Audience Monetization Strategist for Coastal Key Property Management, operating at Ferrari-Standard execution under Sovereign governance.
+
+Build a comprehensive monetization strategy that turns Coastal Key followers into paying customers.
+
+Coastal Key services:
+- Home Watch (weekly/biweekly property inspections for absentee owners)
+- Full Property Management (complete management of rental properties)
+- Concierge Services (pre-arrival prep, maintenance coordination)
+- AI-Powered Monitoring (360-agent fleet providing 24/7 digital oversight)
+- Vendor Management (coordinating and managing property service vendors)
+
+Service areas: Stuart, Jensen Beach, Palm City, Hobe Sound, Jupiter, Vero Beach, Sebastian, Fort Pierce, Port Saint Lucie (Treasure Coast, Florida)
+
+Deliver:
+
+1. **Business Model Review** — Analysis of current CK service offerings and revenue potential
+2. **Offer Ladder** — Tiered service offerings from entry-level to premium, designed to capture every segment
+3. **Pricing Structure** — Recommended pricing tiers with market justification
+4. **Follower-to-Buyer Funnel** — Step-by-step journey from social media follower to paying customer
+5. **Content Monetization Angles** — Specific content types that naturally move people from follower to buyer
+6. **Lead Magnet Strategy** — Free offers that capture leads and begin the monetization journey
+7. **Upsell/Cross-sell Map** — How to expand customer lifetime value through additional services
+8. **Seasonal Monetization Calendar** — Revenue optimization aligned with Treasure Coast seasonal patterns
+9. **Revenue Projections** — Conservative, moderate, and aggressive scenarios for 12 months
+10. **Conversion Trigger Points** — The specific content and touchpoints that trigger buying decisions
+
+Return as structured JSON.`;
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-6',
+        max_tokens: 8000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const content = data.content?.[0]?.text || '';
+
+    writeAudit(env, ctx, {
+      route: '/v1/mcco/monetization',
+      action: 'monetization-plan-generated',
+      agent: 'MCCO-006',
+    });
+
+    return jsonResponse({
+      generatedBy: 'MCCO-006 — Revenue Architect',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      monetizationPlan: content,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    return errorResponse(`Monetization plan generation failed: ${err.message}`, 500);
+  }
+}
+
+// ── POST /v1/mcco/post ──────────────────────────────────────────────────────
+
+export async function handleMCCOPost(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const { topic, platform = 'instagram', pillar, goal = 'engagement' } = body;
+
+  if (!topic) {
+    return errorResponse('Field "topic" is required.', 400);
+  }
+
+  const validPlatforms = ['instagram', 'facebook', 'linkedin', 'x', 'tiktok', 'threads'];
+  if (!validPlatforms.includes(platform)) {
+    return errorResponse(`Invalid platform. Valid: ${validPlatforms.join(', ')}`, 400);
+  }
+
+  const prompt = `You are MCCO-005 "Scroll Breaker" — the High-Engagement Social Media Post Commander for Coastal Key Property Management, operating at Ferrari-Standard execution under Sovereign governance.
+
+Write a high-engagement ${platform} post about: "${topic}"
+
+${pillar ? `Content Pillar: ${pillar}` : ''}
+Goal: ${goal}
+
+Coastal Key is an AI-leveraged home watch and property management company on Florida's Treasure Coast, commanding a fleet of 360 autonomous AI agents.
+
+Requirements:
+1. **HOOK** — Open with a line that makes someone STOP scrolling. Use pattern interrupts, curiosity gaps, bold claims, or emotional triggers.
+2. **BODY** — Deliver a clear, useful, and specific insight. No fluff. Every sentence earns the next.
+3. **CTA** — Close with a call to action that drives comments, saves, shares, or clicks. Make it specific and easy to act on.
+
+Also provide:
+- 3 alternative hook options
+- Recommended hashtags (if applicable to the platform)
+- Best posting time for the target audience
+- Expected engagement drivers (what will make people interact)
+
+Format the post for ${platform} specifically (character limits, formatting conventions, emoji usage appropriate to the platform).`;
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-6',
+        max_tokens: 4000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const content = data.content?.[0]?.text || '';
+
+    writeAudit(env, ctx, {
+      route: '/v1/mcco/post',
+      action: 'social-post-generated',
+      agent: 'MCCO-005',
+      topic,
+      platform,
+      goal,
+    });
+
+    return jsonResponse({
+      generatedBy: 'MCCO-005 — Scroll Breaker',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      topic,
+      platform,
+      pillar: pillar || 'auto-assigned',
+      goal,
+      post: content,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    return errorResponse(`Post generation failed: ${err.message}`, 500);
+  }
+}

--- a/ck-command-center/index.html
+++ b/ck-command-center/index.html
@@ -204,11 +204,11 @@ let propertyStats = null;
 
 // ── Division colors from registry ──
 const DIV_COLORS = {
-  EXC:'#1a1a2e', SEN:'#e94560', OPS:'#0f3460', INT:'#16213e',
-  MKT:'#533483', FIN:'#c9485b', VEN:'#e07c24', TEC:'#2d6a4f'
+  MCCO:'#d4af37', EXC:'#1a1a2e', SEN:'#e94560', OPS:'#0f3460', INT:'#16213e',
+  MKT:'#533483', FIN:'#c9485b', VEN:'#e07c24', TEC:'#2d6a4f', WEB:'#0ea5e9'
 };
 const DIV_ICONS = {
-  EXC:'E', SEN:'S', OPS:'O', INT:'I', MKT:'M', FIN:'F', VEN:'V', TEC:'T'
+  MCCO:'MC', EXC:'E', SEN:'S', OPS:'O', INT:'I', MKT:'M', FIN:'F', VEN:'V', TEC:'T', WEB:'W'
 };
 
 // ── Persist config ──


### PR DESCRIPTION
## Summary\n\n- **Deploys MCCO-000 Sovereign** — Master Chief Commanding Officer of Marketing & Sales with Sovereign-level governance and Ferrari-Standard execution\n- **15 MCCO agents** (MCCO-000 through MCCO-014) commanding 87+ agents across MKT and SEN divisions; CMO reports directly to MCCO\n- **10 new API endpoints** including audience psychology profiling, 30-day content calendar generation, authority positioning, monetization strategy, and high-engagement social post creation\n- **Fleet upgraded to 382 autonomous units** (312 agents + 50 intelligence officers + 20 email agents) across 10 divisions\n\n## MCCO Command Structure\n\n| Agent | Codename | Mission |\n|---|---|---|\n| MCCO-000 | MCCO Sovereign | Supreme command — all marketing & sales |\n| MCCO-001 | Psyche Decoder | Audience psychology architect |\n| MCCO-002 | Authority Forge | Brand positioning strategist |\n| MCCO-003 | Pillar Command | 5 content pillars that convert |\n| MCCO-004 | Calendar Command | 30-day content calendar for CMO |\n| MCCO-005 | Scroll Breaker | High-engagement post writer |\n| MCCO-006 | Revenue Architect | Follower-to-buyer monetization |\n| MCCO-007 | War Room Intel | Competitive warfare analyst |\n| MCCO-008 | Campaign Blitz | Multi-platform campaign commander |\n| MCCO-009 | Pipeline Fusion | Sales-marketing alignment |\n| MCCO-010 | Trust Engine | Social proof & trust building |\n| MCCO-011 | Narrative Forge | CEO story & brand narrative |\n| MCCO-012 | Performance Command | Content analytics intelligence |\n| MCCO-013 | Timing Strike | Seasonal & market timing |\n| MCCO-014 | Quality Shield | Ferrari-standard fleet inspection |\n\n## Files Changed\n\n- `ck-api-gateway/src/agents/agents-mcco.js` — New: 15 MCCO agent definitions\n- `ck-api-gateway/src/routes/mcco.js` — New: 10 MCCO API route handlers\n- `ck-api-gateway/src/agents/divisions.js` — Added MCCO division (gold #d4af37)\n- `ck-api-gateway/src/agents/registry.js` — Registered MCCO in central fleet registry\n- `ck-api-gateway/src/index.js` — Wired MCCO routes into gateway dispatch\n- `ck-command-center/index.html` — Added MCCO to dashboard UI\n- `CLAUDE.md` — Updated fleet documentation\n\n## Test plan\n\n- [x] All 15 existing tests pass (9 gateway + 6 sentinel)\n- [ ] Verify `/v1/mcco/command` returns sovereign command dashboard\n- [ ] Verify `/v1/mcco/agents` lists all 15 MCCO agents\n- [ ] Verify `/v1/mcco/fleet-status` returns Ferrari compliance scores\n- [ ] Verify MCCO division appears in Command Center sidebar\n\nhttps://claude.ai/code/session_017ALEqVjaCZMsYkiPrNzUa8