### PR TITLE
Add Peak Performance Frameworks module

### DIFF
--- a/ck-api-gateway/src/frameworks/peak-performance.js
+++ b/ck-api-gateway/src/frameworks/peak-performance.js
@@ -1,0 +1,441 @@
+/**
+ * Peak Performance Frameworks — Sovereign Knowledge Base
+ *
+ * Integrated leadership, productivity, sales, and mindset frameworks
+ * powering the MCCO content engine and fleet operational excellence.
+ *
+ * Sources: Dan Koe, Steve Jobs, P.A.R.A. Method, Flow State Research,
+ *          Eisenhower Matrix, Pomodoro Technique, and modern productivity science.
+ */
+
+// ── Framework 1: Get Ahead of 99% (Dan Koe) ────────────────────────────────
+
+export const GET_AHEAD_FRAMEWORK = {
+  id: 'FW-001',
+  name: 'Get Ahead of 99% of People',
+  author: 'Dan Koe',
+  category: 'mindset',
+  summary: 'Define what you don\'t want, eliminate distractions, master fundamentals, and embrace trial and error to achieve long-term success.',
+  quote: 'Flip the switch inside of you — build a foundation into the life you want.',
+  steps: [
+    {
+      step: 1,
+      title: 'Create Your Anti-Vision',
+      description: 'A detailed picture of everything you don\'t want in life — mindless routines, chaos, and unfulfilling outcomes.',
+      keyInsight: 'Helps clarify what you truly desire by contrasting it with what you fear or despise.',
+      howToBuild: [
+        'Sit with a notebook for 30 minutes and write down all the things you want to avoid in your future (e.g., unhealthy habits, meaningless work).',
+        'Use this discomfort as fuel to define your actual vision — the opposite of your anti-vision.',
+      ],
+    },
+    {
+      step: 2,
+      title: 'Disappear for Six Months',
+      description: 'Cut out distractions like social media, toxic relationships, or habits that drain your energy.',
+      keyInsight: 'You don\'t need to explain yourself — just commit fully to your goals without external validation.',
+      howToBuild: [
+        'Focus entirely on building the systems and routines that align with your vision.',
+        'Eliminate anything that doesn\'t serve your long-term goals.',
+      ],
+    },
+    {
+      step: 3,
+      title: 'Master the Fundamentals',
+      description: 'Success comes from repetitive actions that build mastery over time.',
+      keyInsight: 'Like leveling up in a game, these small actions compound over time, creating exponential growth.',
+      examples: [
+        'Writing daily',
+        'Exercising consistently',
+        'Practicing foundational skills in your craft',
+      ],
+    },
+    {
+      step: 4,
+      title: 'Embrace Trial and Error',
+      description: 'Treat your life as a project that requires constant experimentation and adjustment.',
+      keyInsight: 'Success isn\'t instant — it takes years of consistent effort and learning from failures.',
+      principles: [
+        'Think like a scientist',
+        'Long-term perspective over short-term gratification',
+      ],
+    },
+  ],
+  applicationToPropertyManagement: {
+    antiVision: 'Properties neglected, vendors unaccountable, owners anxious — the opposite of what Coastal Key delivers.',
+    disappear: 'Block out noise from competitors; focus on building the AI fleet and operational excellence.',
+    fundamentals: 'Daily inspections, consistent reporting, vendor follow-through — the boring work that compounds into trust.',
+    trialAndError: 'Test new AI agent capabilities, iterate on client communication, refine pricing models.',
+  },
+};
+
+// ── Framework 2: P.A.R.A. Method ────────────────────────────────────────────
+
+export const PARA_METHOD = {
+  id: 'FW-002',
+  name: 'P.A.R.A. Method — Organize Your Ideas',
+  author: 'Tiago Forte',
+  category: 'organization',
+  summary: 'The purpose of building a second brain is not just to store information, but to make it useful and accessible to improve the quality of your work and life.',
+  components: {
+    projects: {
+      letter: 'P',
+      definition: 'Sets of tasks with a defined goal and deadline.',
+      example: 'Preparing a presentation for a conference.',
+    },
+    areas: {
+      letter: 'A',
+      definition: 'Aspects of your life that need ongoing maintenance.',
+      example: 'Health, personal finances.',
+    },
+    resources: {
+      letter: 'R',
+      definition: 'Collections of thematic information that interest you.',
+      example: 'Articles about productivity, graphic design courses.',
+    },
+    archives: {
+      letter: 'A',
+      definition: 'Valuable past information you want to keep but are not currently using actively.',
+      example: 'Completed project files, old academic papers.',
+    },
+  },
+  basicPrinciples: {
+    capture: 'Proactively collect all ideas, thoughts, quotes, and any type of relevant information. Use digital or physical tools, but make sure it\'s easy to review and access.',
+    organize: 'Create a system that allows you to store your information in a way that you can easily find it when you need it. Use tags, folders, or any method that works for you.',
+    distill: 'Regularly review your collected content to summarize, condense, or otherwise transform the information into something more digestible and useful.',
+    express: 'Use your second brain to create new content, make informed decisions, or enhance your learning. The goal is to make accumulated knowledge tangible.',
+  },
+  recommendedTools: [
+    'Evernote, Notion, Roam Research, or Obsidian (capture & organize)',
+    'Trello, Asana, or Todoist (project management)',
+    'Google Drive, Dropbox, or local files (digital filing)',
+  ],
+  practicalTips: [
+    'Dedicate time each week to review and organize your second brain.',
+    'Be flexible with your system; allow it to evolve as your needs and discoveries change.',
+    'Don\'t just store information; reflect on it and find ways to apply it in your life and work.',
+  ],
+  applicationToPropertyManagement: {
+    projects: 'Active client onboarding, seasonal prep campaigns, AI fleet upgrades.',
+    areas: 'Property inspections, vendor management, client communications, compliance.',
+    resources: 'Market data, competitor intel, insurance regulations, maintenance best practices.',
+    archives: 'Completed inspection reports, closed client files, historical market data.',
+  },
+};
+
+// ── Framework 3: Steve Jobs\' 8 Rules for Sales Excellence ──────────────────
+
+export const JOBS_SALES_RULES = {
+  id: 'FW-003',
+  name: 'Steve Jobs\' 8 Rules for Sales Excellence',
+  author: 'Steve Jobs',
+  category: 'sales',
+  summary: 'Eight principles for creating irresistible products and closing sales with conviction, storytelling, and relentless focus on the customer experience.',
+  rules: [
+    {
+      rule: 1,
+      title: 'Create a Unique Value Proposition',
+      principles: [
+        'Differentiate your product',
+        'Highlight unique problem-solving aspects',
+        'Communicate passion for your offering',
+      ],
+      quote: 'You\'ve got to find what you love. And that is as true for your work as it is for your lovers.',
+    },
+    {
+      rule: 2,
+      title: 'Focus on Benefits, Not Features',
+      principles: [
+        'Emphasize how product improves lives',
+        'Translate specs into customer advantages',
+        'Sell the experience, not just the product',
+      ],
+      quote: 'You\'ve got to start with the customer experience and work back toward the technology — not the other way around.',
+    },
+    {
+      rule: 3,
+      title: 'Keep Your Message Simple',
+      principles: [
+        'Craft clear, concise presentations',
+        'Avoid overwhelming with technical details',
+        'Distill complex ideas into simple messages',
+      ],
+      quote: 'That\'s been one of my mantras — focus and simplicity. Simple can be harder than complex.',
+    },
+    {
+      rule: 4,
+      title: 'Tell a Compelling Story',
+      principles: [
+        'Use narratives to make products relatable',
+        'Connect emotionally with your audience',
+        'Share impactful success stories',
+      ],
+      quote: 'The most powerful person in the world is the storyteller. The storyteller sets the vision, values and agenda of an entire generation that is to come.',
+    },
+    {
+      rule: 5,
+      title: 'Know Your Audience',
+      principles: [
+        'Research prospects thoroughly',
+        'Understand pain points and needs',
+        'Customize approach based on customer profile',
+      ],
+      quote: 'Get closer than ever to your customers. So close that you tell them what they need well before they realize it themselves.',
+    },
+    {
+      rule: 6,
+      title: 'Create an Experience, Not Just a Product',
+      principles: [
+        'Focus on entire customer journey',
+        'Ensure positive touchpoints throughout',
+        'Prioritize customer experience in sales process',
+      ],
+      quote: 'You\'ve got to start with the customer experience and work back toward the technology — not the other way around.',
+    },
+    {
+      rule: 7,
+      title: 'Don\'t Be Afraid to Polarize',
+      principles: [
+        'Confidently highlight strengths',
+        'Take bold positions in the market',
+        'Stand out rather than blend in',
+      ],
+      quote: 'A lot of times, people don\'t know what they want until you show it to them.',
+    },
+    {
+      rule: 8,
+      title: 'Persistence in the Face of Rejection',
+      principles: [
+        'Use rejection as a learning opportunity',
+        'Adjust approach and keep pushing',
+        'Stay committed to your vision',
+      ],
+      quote: 'I\'m convinced that about half of what separates successful entrepreneurs from the non-successful ones is pure perseverance.',
+    },
+  ],
+  applicationToPropertyManagement: {
+    uvp: 'Coastal Key is the ONLY AI-powered property management company on the Treasure Coast with a 382-agent autonomous fleet.',
+    benefitsNotFeatures: 'Don\'t sell "AI inspections" — sell "peace of mind knowing your property is monitored 24/7 while you\'re 1,000 miles away."',
+    simpleMessage: 'Your property. Our AI. Zero surprises.',
+    compellingStory: 'Share the founder journey — from frustration with traditional property management to building a 382-agent AI fleet.',
+    knowAudience: 'Absentee homeowners fear the unknown. Snowbirds want worry-free seasonal transitions. Luxury investors demand premium service.',
+    experience: 'From first call to monthly report — every touchpoint should feel premium and effortless.',
+    polarize: 'Traditional property management is broken. We don\'t just manage properties — we deploy an AI army to protect them.',
+    persistence: 'Follow up relentlessly. The prospect who says no today has a property issue tomorrow.',
+  },
+};
+
+// ── Framework 4: 8 Hours of Work in 4 Hours ────────────────────────────────
+
+export const PRODUCTIVITY_8_IN_4 = {
+  id: 'FW-004',
+  name: '8 Hours of Work Finished in 4 Hours',
+  author: 'Colby Kultgen',
+  category: 'productivity',
+  summary: 'Leverage time blocking, Parkinson\'s Law, and personalized work styles to double productivity by working smarter, not longer.',
+  strategies: [
+    {
+      title: 'Block Out Your Day',
+      description: 'Focus on one task at a time during a dedicated block. Group similar activities to streamline your day and minimize context switching. Stick to your schedule to build momentum and efficiency.',
+    },
+    {
+      title: 'Set Artificial Deadlines (Parkinson\'s Law)',
+      description: 'Break tasks into smaller steps and assign tight deadlines to each. Shorter timeframes force focus and prevent procrastination, making it easier to stay on track and accomplish more in less time.',
+      principle: 'Work expands to fill the time allotted — so shrink the time allotted.',
+    },
+    {
+      title: 'Find Your Ideal Work Style',
+      description: 'Experiment with different approaches to work to discover what keeps you motivated and productive. Tailor your routine to your strengths to maximize your output.',
+      workStyles: [
+        {
+          style: 'Planner',
+          routine: 'Plan your day hour by hour → Deep work for 2 hours → Take a stretching break → Work on lighter tasks',
+        },
+        {
+          style: 'Prioritizer',
+          routine: 'Write a to-do list → Organize your calendar → Start with the hardest tasks first → Deep work for 2 hours',
+        },
+        {
+          style: 'Arranger',
+          routine: 'Plan your day hour by hour → Deep work for 2 hours → Take a stretching break → Work on lighter tasks',
+        },
+        {
+          style: 'Visualizer',
+          routine: 'Decide on a priority for the day → Write in your journal → Use the Pomodoro technique → End the day with light tasks',
+        },
+      ],
+    },
+  ],
+  applicationToPropertyManagement: {
+    timeBlocking: 'Inspections 8-12, client reports 12-1, vendor calls 1-3, strategy 3-5. AI handles async 24/7.',
+    parkinsonsLaw: 'Set 48-hour SLAs for vendor responses instead of "when they get to it." AI agents enforce deadlines.',
+    workStyles: 'Match agent task routing to optimal work patterns — batch similar inspections, cluster vendor follow-ups.',
+  },
+};
+
+// ── Framework 5: Flow State ─────────────────────────────────────────────────
+
+export const FLOW_STATE_FRAMEWORK = {
+  id: 'FW-005',
+  name: 'How to Get Into Flow State',
+  category: 'performance',
+  summary: 'When your body and mind seamlessly connect, leading to intense focus and effortless engagement, often described as being "in the zone" — and it\'s accessible to everyone.',
+  vennDiagram: {
+    circles: [
+      'Something you care about',
+      'Something long term',
+      'Something challenging',
+      'Something you\'re good at',
+    ],
+    center: 'FLOW STATE',
+  },
+  outcomes: {
+    fulfilment: {
+      intersection: 'Something you care about + Something long term',
+      traits: [
+        'Achieving goals effortlessly',
+        'Deep sense of purpose and satisfaction',
+        'Engaging in activities that align with personal values',
+      ],
+    },
+    happiness: {
+      intersection: 'Something you care about + Something you\'re good at',
+      traits: [
+        'Immersion in the present moment',
+        'Feelings of joy and contentment',
+        'Experiencing a sense of timelessness',
+      ],
+    },
+    persistence: {
+      intersection: 'Something long term + Something challenging',
+      traits: [
+        'Continuous focus and determination',
+        'Overcoming challenges with ease',
+        'Energised and motivated to overcome obstacles',
+      ],
+    },
+    clarity: {
+      intersection: 'Something challenging + Something you\'re good at',
+      traits: [
+        'Clear understanding of goals and objectives',
+        'Enhanced mental clarity and focus',
+        'Heightened awareness of surroundings and actions',
+      ],
+    },
+  },
+  applicationToPropertyManagement: {
+    careAbout: 'Protecting homeowners\' most valuable assets — this must be the genuine mission, not just a business.',
+    longTerm: 'Building the premier AI-powered property management platform is a multi-year vision.',
+    challenging: 'Scaling a 382-agent AI fleet while maintaining Ferrari-standard quality is the right level of difficulty.',
+    goodAt: 'Deep Treasure Coast knowledge + AI orchestration = a unique skill stack no competitor has.',
+    flowTrigger: 'When all four align, the team operates in flow — inspections feel effortless, content creates itself, clients refer naturally.',
+  },
+};
+
+// ── Framework 6: Productivity Techniques Toolkit ────────────────────────────
+
+export const PRODUCTIVITY_TECHNIQUES = {
+  id: 'FW-006',
+  name: 'Productivity Techniques Toolkit',
+  category: 'productivity',
+  summary: 'Six proven productivity methodologies for maximizing output: Pomodoro, 3/3/3, Eisenhower Matrix, Eat the Frog, Seinfeld Strategy, and Time Blocking.',
+  techniques: [
+    {
+      name: 'Pomodoro Technique',
+      steps: [
+        'List your tasks.',
+        'Set a 25-min timer.',
+        'Focus and work.',
+        'Take a 5-min break.',
+        'Repeat 4 times, then break for longer.',
+      ],
+      bestFor: 'Deep focus work, content creation, report writing.',
+    },
+    {
+      name: '3/3/3 Method',
+      structure: {
+        first3: 'Spend 3 hours working on an important project.',
+        second3: 'Complete 3 shorter urgent tasks or meetings.',
+        third3: 'Do 3 maintenance tasks to keep life running smoothly.',
+      },
+      bestFor: 'Balanced daily planning, ensures both deep work and operations get attention.',
+    },
+    {
+      name: 'Eisenhower Matrix',
+      quadrants: {
+        urgentImportant: { action: 'Do it', description: 'Critical tasks requiring immediate attention.' },
+        notUrgentImportant: { action: 'Schedule it', description: 'Strategic tasks that build long-term value.' },
+        urgentNotImportant: { action: 'Delegate it', description: 'Tasks that need doing but not by you.' },
+        notUrgentNotImportant: { action: 'Eliminate it', description: 'Time wasters to remove entirely.' },
+      },
+      bestFor: 'Task prioritization, delegation decisions, eliminating busywork.',
+    },
+    {
+      name: 'Eat the Frog',
+      principle: 'Do your hardest task first. The rest will be easier.',
+      quote: 'If it\'s your job to eat a frog, it\'s best to do it first thing in the morning. And if it\'s your job to eat two frogs, it\'s best to eat the biggest one first. — Mark Twain',
+      bestFor: 'Overcoming procrastination, tackling high-impact tasks.',
+    },
+    {
+      name: 'Seinfeld Strategy',
+      steps: [
+        'Set your goal.',
+        'Mark a calendar each day you do it.',
+        'Keep the streak as long as you can.',
+        'Never miss 2 days in a row.',
+      ],
+      bestFor: 'Building habits, daily consistency, compound growth.',
+    },
+    {
+      name: 'Time Blocking',
+      steps: [
+        'Identify what needs done.',
+        'Group similar activities together.',
+        'Assign time slots for tasks.',
+        'Plot blocks on a calendar.',
+        'Stick to the schedule.',
+        'Take breaks between blocks.',
+        'Make changes if needed.',
+      ],
+      exampleSchedule: {
+        '9-12': 'Deep Work',
+        '12-12:30': 'Email',
+        '12:30-1': 'Lunch',
+        '1-2': 'Gym',
+        '2-2:30': 'Break',
+        '2:30-4': 'Meetings',
+      },
+      bestFor: 'Full day planning, context-switch reduction, work-life boundaries.',
+    },
+  ],
+  applicationToPropertyManagement: {
+    pomodoro: 'AI agents use 25-min inspection cycles with automated break periods for system health checks.',
+    threeThreeThree: '3 hours on high-priority inspections, 3 urgent vendor follow-ups, 3 maintenance reports.',
+    eisenhower: 'Urgent+Important: emergency property issues. Not Urgent+Important: preventive maintenance. Urgent+Not Important: delegate to AI agents. Not Urgent+Not Important: eliminate from the pipeline.',
+    eatTheFrog: 'Tackle the most complex property inspection or the most difficult client conversation first each morning.',
+    seinfeld: 'Never miss 2 days of property check-ins. Build the streak. Consistency builds trust with absentee owners.',
+    timeBlocking: 'Structured daily operations: morning inspections, midday reporting, afternoon vendor coordination, evening client comms.',
+  },
+};
+
+// ── Master Framework Registry ───────────────────────────────────────────────
+
+export const FRAMEWORKS = [
+  GET_AHEAD_FRAMEWORK,
+  PARA_METHOD,
+  JOBS_SALES_RULES,
+  PRODUCTIVITY_8_IN_4,
+  FLOW_STATE_FRAMEWORK,
+  PRODUCTIVITY_TECHNIQUES,
+];
+
+export const FRAMEWORK_BY_ID = new Map(FRAMEWORKS.map(f => [f.id, f]));
+
+export const FRAMEWORKS_BY_CATEGORY = {
+  mindset: FRAMEWORKS.filter(f => f.category === 'mindset'),
+  organization: FRAMEWORKS.filter(f => f.category === 'organization'),
+  sales: FRAMEWORKS.filter(f => f.category === 'sales'),
+  productivity: FRAMEWORKS.filter(f => f.category === 'productivity'),
+  performance: FRAMEWORKS.filter(f => f.category === 'performance'),
+};
+
+export const FRAMEWORK_CATEGORIES = Object.keys(FRAMEWORKS_BY_CATEGORY);

--- a/ck-api-gateway/src/index.js
+++ b/ck-api-gateway/src/index.js
@@ -63,6 +63,13 @@
  *   POST /v1/atlas/campaigns              — Create a new Atlas campaign
  *   GET  /v1/atlas/audit                  — Audit required CKPM campaigns
  *   GET  /v1/atlas/health                 — Atlas AI connectivity check
+ *   GET  /v1/frameworks                   — List all Peak Performance Frameworks
+ *   GET  /v1/frameworks/category/:cat     — Get frameworks by category
+ *   GET  /v1/frameworks/:id               — Get single framework
+ *   POST /v1/frameworks/apply             — AI-apply framework to business scenario
+ *   POST /v1/frameworks/content           — Generate content using framework principles
+ *   POST /v1/frameworks/sales-playbook    — Generate sales playbook from framework rules
+ *   POST /v1/frameworks/productivity-plan — Generate agent/team productivity plan
  *
  * Auth: Bearer token via WORKER_AUTH_TOKEN secret
  */
@@ -82,6 +89,7 @@ import { handlePricingRecommend, handlePricingZones } from './routes/pricing.js'
 import { handleListOfficers, handleGetOfficer, handleOfficerScan, handleOfficerDashboard, handleFleetScan } from './routes/intelligence-officers.js';
 import { handleListEmailAgents, handleGetEmailAgent, handleEmailCompose, handleEmailClassify, handleEmailDashboard } from './routes/email-agents.js';
 import { handleListMCCOAgents, handleGetMCCOAgent, handleMCCOCommand, handleMCCOFleetStatus, handleMCCODirective, handleMCCOContentCalendar, handleMCCOAudienceProfile, handleMCCOPositioning, handleMCCOMonetization, handleMCCOPost } from './routes/mcco.js';
+import { handleListFrameworks, handleGetFramework, handleGetFrameworksByCategory, handleFrameworkApply, handleFrameworkContent, handleFrameworkSalesPlaybook, handleFrameworkProductivityPlan } from './routes/frameworks.js';
 import { handleAtlasCampaigns, handleAtlasCampaignById, handleAtlasCampaignStatus, handleAtlasOverviewStats, handleAtlasCampaignStatsById, handleAtlasCallRecords, handleAtlasCallRecordDetail, handleAtlasScheduleCall, handleAtlasCampaignBookings, handleAtlasKBFiles, handleAtlasSpeedToLead, handleAtlasCreateCampaign, handleAtlasSetupRevival, handleAtlasAudit, handleAtlasHealth } from './routes/atlas.js';
 import { jsonResponse, errorResponse, corsHeaders } from './utils/response.js';
 
@@ -105,7 +113,7 @@ export default {
           status: 'operational',
           service: 'ck-api-gateway',
           version: '2.0.0',
-          agents: 312,
+          agents: 382,
           divisions: 10,
           timestamp: new Date().toISOString(),
         });
@@ -456,6 +464,37 @@ export default {
       if (path.match(/^\/v1\/atlas\/campaigns\/[^/]+$/) && method === 'GET') {
         const campaignId = path.split('/v1/atlas/campaigns/')[1];
         return await handleAtlasCampaignById(campaignId, env);
+      }
+
+      // ── Peak Performance Frameworks ──
+      if (path === '/v1/frameworks' && method === 'GET') {
+        return handleListFrameworks(url);
+      }
+
+      if (path === '/v1/frameworks/apply' && method === 'POST') {
+        return await handleFrameworkApply(request, env, ctx);
+      }
+
+      if (path === '/v1/frameworks/content' && method === 'POST') {
+        return await handleFrameworkContent(request, env, ctx);
+      }
+
+      if (path === '/v1/frameworks/sales-playbook' && method === 'POST') {
+        return await handleFrameworkSalesPlaybook(request, env, ctx);
+      }
+
+      if (path === '/v1/frameworks/productivity-plan' && method === 'POST') {
+        return await handleFrameworkProductivityPlan(request, env, ctx);
+      }
+
+      if (path.match(/^\/v1\/frameworks\/category\/[^/]+$/) && method === 'GET') {
+        const category = path.split('/v1/frameworks/category/')[1];
+        return handleGetFrameworksByCategory(category);
+      }
+
+      if (path.match(/^\/v1\/frameworks\/[^/]+$/) && method === 'GET') {
+        const frameworkId = path.split('/v1/frameworks/')[1];
+        return handleGetFramework(frameworkId);
       }
 
       return errorResponse('Not found', 404);

--- a/ck-api-gateway/src/routes/frameworks.js
+++ b/ck-api-gateway/src/routes/frameworks.js
@@ -1,0 +1,476 @@
+/**
+ * Peak Performance Frameworks Routes
+ *
+ * Sovereign-integrated knowledge base powering MCCO content generation,
+ * SEN sales training, and fleet operational productivity.
+ *
+ *   GET  /v1/frameworks                     — List all frameworks
+ *   GET  /v1/frameworks/:id                 — Get single framework
+ *   GET  /v1/frameworks/category/:category  — Get frameworks by category
+ *   POST /v1/frameworks/apply               — AI-apply a framework to a business scenario
+ *   POST /v1/frameworks/content             — Generate content using framework principles
+ *   POST /v1/frameworks/sales-playbook      — Generate sales playbook from Jobs' rules
+ *   POST /v1/frameworks/productivity-plan   — Generate agent/team productivity plan
+ */
+
+import {
+  FRAMEWORKS,
+  FRAMEWORK_BY_ID,
+  FRAMEWORKS_BY_CATEGORY,
+  FRAMEWORK_CATEGORIES,
+  GET_AHEAD_FRAMEWORK,
+  PARA_METHOD,
+  JOBS_SALES_RULES,
+  PRODUCTIVITY_8_IN_4,
+  FLOW_STATE_FRAMEWORK,
+  PRODUCTIVITY_TECHNIQUES,
+} from '../frameworks/peak-performance.js';
+import { writeAudit } from '../utils/audit.js';
+import { jsonResponse, errorResponse } from '../utils/response.js';
+
+// ── GET /v1/frameworks ──────────────────────────────────────────────────────
+
+export function handleListFrameworks(url) {
+  const category = url.searchParams.get('category');
+  const search = url.searchParams.get('search');
+
+  let results = [...FRAMEWORKS];
+
+  if (category) {
+    if (!FRAMEWORK_CATEGORIES.includes(category)) {
+      return errorResponse(`Invalid category. Valid: ${FRAMEWORK_CATEGORIES.join(', ')}`, 400);
+    }
+    results = results.filter(f => f.category === category);
+  }
+
+  if (search) {
+    const lower = search.toLowerCase();
+    results = results.filter(
+      f =>
+        f.name.toLowerCase().includes(lower) ||
+        f.summary.toLowerCase().includes(lower) ||
+        f.category.toLowerCase().includes(lower),
+    );
+  }
+
+  return jsonResponse({
+    frameworks: results.map(f => ({
+      id: f.id,
+      name: f.name,
+      author: f.author || 'Various',
+      category: f.category,
+      summary: f.summary,
+    })),
+    count: results.length,
+    categories: FRAMEWORK_CATEGORIES,
+    governance: 'sovereign',
+    module: 'Peak Performance Frameworks',
+  });
+}
+
+// ── GET /v1/frameworks/:id ──────────────────────────────────────────────────
+
+export function handleGetFramework(frameworkId) {
+  const framework = FRAMEWORK_BY_ID.get(frameworkId);
+  if (!framework) {
+    return errorResponse(`Framework "${frameworkId}" not found. Valid IDs: ${FRAMEWORKS.map(f => f.id).join(', ')}`, 404);
+  }
+  return jsonResponse({ framework });
+}
+
+// ── GET /v1/frameworks/category/:category ───────────────────────────────────
+
+export function handleGetFrameworksByCategory(category) {
+  if (!FRAMEWORK_CATEGORIES.includes(category)) {
+    return errorResponse(`Invalid category. Valid: ${FRAMEWORK_CATEGORIES.join(', ')}`, 400);
+  }
+  const results = FRAMEWORKS_BY_CATEGORY[category];
+  return jsonResponse({
+    category,
+    frameworks: results,
+    count: results.length,
+  });
+}
+
+// ── POST /v1/frameworks/apply ───────────────────────────────────────────────
+
+export async function handleFrameworkApply(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const { frameworkId, scenario, targetAudience = 'property owners' } = body;
+
+  if (!frameworkId || !scenario) {
+    return errorResponse('Fields "frameworkId" and "scenario" are required.', 400);
+  }
+
+  const framework = FRAMEWORK_BY_ID.get(frameworkId);
+  if (!framework) {
+    return errorResponse(`Framework "${frameworkId}" not found.`, 404);
+  }
+
+  const prompt = `You are the MCCO Sovereign Intelligence operating at Ferrari-Standard execution for Coastal Key Property Management.
+
+You have been given a Peak Performance Framework and a business scenario. Apply the framework principles to generate actionable strategic recommendations.
+
+## Framework: ${framework.name}
+${JSON.stringify(framework, null, 2)}
+
+## Scenario to Address:
+${scenario}
+
+## Target Audience: ${targetAudience}
+
+## Context:
+Coastal Key is an AI-leveraged home watch and property management company on Florida's Treasure Coast, commanding a fleet of 382 autonomous AI agents across 10 divisions. The company serves absentee homeowners, seasonal residents, luxury investors, and snowbirds.
+
+Apply EVERY principle from this framework to the scenario. For each principle/step:
+1. Explain how it applies to this specific scenario
+2. Provide a concrete action item Coastal Key can execute this week
+3. Include a specific content idea or talking point tied to the principle
+4. Assign the recommended MCCO agent or division to execute
+
+Return as structured JSON with: frameworkApplication, actionItems, contentIdeas, assignedAgents, expectedOutcomes, timeline.`;
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-6',
+        max_tokens: 6000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const content = data.content?.[0]?.text || '';
+
+    writeAudit(env, ctx, {
+      route: '/v1/frameworks/apply',
+      action: 'framework-applied',
+      frameworkId,
+      frameworkName: framework.name,
+      scenario,
+    });
+
+    return jsonResponse({
+      generatedBy: 'MCCO Sovereign Intelligence',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      framework: { id: framework.id, name: framework.name, category: framework.category },
+      scenario,
+      targetAudience,
+      application: content,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    return errorResponse(`Framework application failed: ${err.message}`, 500);
+  }
+}
+
+// ── POST /v1/frameworks/content ─────────────────────────────────────────────
+
+export async function handleFrameworkContent(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const { topic, frameworks: requestedFrameworks, platform = 'linkedin', contentType = 'post' } = body;
+
+  if (!topic) {
+    return errorResponse('Field "topic" is required.', 400);
+  }
+
+  // If specific frameworks requested, validate; otherwise use all
+  let selectedFrameworks = FRAMEWORKS;
+  if (requestedFrameworks && Array.isArray(requestedFrameworks)) {
+    selectedFrameworks = requestedFrameworks
+      .map(id => FRAMEWORK_BY_ID.get(id))
+      .filter(Boolean);
+    if (selectedFrameworks.length === 0) {
+      return errorResponse('No valid framework IDs provided.', 400);
+    }
+  }
+
+  const frameworkSummaries = selectedFrameworks.map(f =>
+    `### ${f.name} (${f.category})\n${f.summary}\nKey Application: ${JSON.stringify(f.applicationToPropertyManagement)}`
+  ).join('\n\n');
+
+  const prompt = `You are MCCO-005 "Scroll Breaker" enhanced with the Peak Performance Frameworks knowledge base, operating at Ferrari-Standard execution under Sovereign governance.
+
+Generate a high-engagement ${contentType} for ${platform} about: "${topic}"
+
+## Peak Performance Frameworks to Weave In:
+${frameworkSummaries}
+
+## Context:
+Coastal Key Property Management — AI-leveraged home watch and property management on Florida's Treasure Coast. 382-agent autonomous AI fleet. Serves absentee homeowners, seasonal residents, luxury investors, snowbirds.
+
+## Requirements:
+1. **HOOK** — A pattern-interrupting first line that stops the scroll
+2. **BODY** — Weave framework principles naturally into the narrative. Don't lecture — teach through story and insight
+3. **FRAMEWORK CALLOUT** — Name-drop at least one framework principle as an authority signal
+4. **CTA** — Drive engagement: comments, saves, shares, or website visits
+
+Also provide:
+- 3 alternative hooks
+- Which framework(s) were most prominently featured
+- Recommended hashtags
+- Best posting time for Treasure Coast audience
+- Content pillar alignment (AI-Powered Protection / Treasure Coast Lifestyle / CEO Journey / Property Owner Education / Results & Social Proof)
+
+Format for ${platform} conventions.`;
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-6',
+        max_tokens: 5000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const content = data.content?.[0]?.text || '';
+
+    writeAudit(env, ctx, {
+      route: '/v1/frameworks/content',
+      action: 'framework-content-generated',
+      topic,
+      platform,
+      contentType,
+      frameworksUsed: selectedFrameworks.map(f => f.id),
+    });
+
+    return jsonResponse({
+      generatedBy: 'MCCO-005 — Scroll Breaker + Peak Performance Frameworks',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      topic,
+      platform,
+      contentType,
+      frameworksApplied: selectedFrameworks.map(f => ({ id: f.id, name: f.name })),
+      content,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    return errorResponse(`Framework content generation failed: ${err.message}`, 500);
+  }
+}
+
+// ── POST /v1/frameworks/sales-playbook ──────────────────────────────────────
+
+export async function handleFrameworkSalesPlaybook(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const { segment = 'all', objection, scenario } = body;
+
+  const validSegments = ['absentee_homeowner', 'seasonal_resident', 'luxury_investor', 'snowbird', 'single_family', 'all'];
+  if (!validSegments.includes(segment)) {
+    return errorResponse(`Invalid segment. Valid: ${validSegments.join(', ')}`, 400);
+  }
+
+  const prompt = `You are MCCO-009 "Pipeline Fusion" — Sales-Marketing Alignment Commander, enhanced with the Peak Performance Frameworks knowledge base. Ferrari-Standard execution, Sovereign governance.
+
+Build a comprehensive sales playbook for Coastal Key Property Management's Sentinel Sales (SEN) division.
+
+## Steve Jobs' 8 Rules for Sales Excellence:
+${JSON.stringify(JOBS_SALES_RULES.rules, null, 2)}
+
+## Dan Koe's "Get Ahead" Framework:
+${JSON.stringify(GET_AHEAD_FRAMEWORK.steps, null, 2)}
+
+## Flow State Framework:
+${JSON.stringify(FLOW_STATE_FRAMEWORK.outcomes, null, 2)}
+
+## Target Segment: ${segment}
+${objection ? `## Specific Objection to Handle: ${objection}` : ''}
+${scenario ? `## Sales Scenario: ${scenario}` : ''}
+
+## Context:
+Coastal Key — AI-leveraged home watch and property management, Treasure Coast Florida. 382-agent AI fleet. 40 Sentinel Sales agents making 2,400+ calls daily via Retell AI.
+
+## Deliver:
+
+1. **Opening Script** — Apply Jobs Rule #1 (UVP) + Rule #4 (Compelling Story) to craft an irresistible opening
+2. **Pain Discovery Questions** — 5 questions based on Jobs Rule #5 (Know Your Audience) that uncover deep pain points
+3. **Value Presentation** — Apply Jobs Rule #2 (Benefits Not Features) + Rule #6 (Experience Not Product) to present CK's services
+4. **Objection Handling** — Handle top 5 objections using Jobs Rule #8 (Persistence) + Dan Koe's "Embrace Trial and Error"
+5. **Closing Framework** — Apply Jobs Rule #7 (Polarize) to create urgency and close
+6. **Follow-Up Sequence** — 7-day nurture sequence applying the Seinfeld Strategy (never miss 2 days)
+7. **Flow State Tips for Agents** — How SEN agents can enter flow state during call blocks
+8. **Productivity Schedule** — Optimal daily call schedule using Pomodoro + Time Blocking + Eat the Frog
+
+Return as structured JSON.`;
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-6',
+        max_tokens: 8000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const content = data.content?.[0]?.text || '';
+
+    writeAudit(env, ctx, {
+      route: '/v1/frameworks/sales-playbook',
+      action: 'sales-playbook-generated',
+      agent: 'MCCO-009',
+      segment,
+    });
+
+    return jsonResponse({
+      generatedBy: 'MCCO-009 — Pipeline Fusion + Peak Performance Frameworks',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      segment,
+      frameworksApplied: [
+        { id: 'FW-003', name: JOBS_SALES_RULES.name },
+        { id: 'FW-001', name: GET_AHEAD_FRAMEWORK.name },
+        { id: 'FW-005', name: FLOW_STATE_FRAMEWORK.name },
+        { id: 'FW-006', name: PRODUCTIVITY_TECHNIQUES.name },
+      ],
+      salesPlaybook: content,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    return errorResponse(`Sales playbook generation failed: ${err.message}`, 500);
+  }
+}
+
+// ── POST /v1/frameworks/productivity-plan ───────────────────────────────────
+
+export async function handleFrameworkProductivityPlan(request, env, ctx) {
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse('Request body must be valid JSON.', 400);
+  }
+
+  const { division, role = 'agent', goals = [] } = body;
+
+  const validDivisions = ['MCCO', 'EXC', 'SEN', 'OPS', 'INT', 'MKT', 'FIN', 'VEN', 'TEC', 'WEB', 'all'];
+  if (division && !validDivisions.includes(division)) {
+    return errorResponse(`Invalid division. Valid: ${validDivisions.join(', ')}`, 400);
+  }
+
+  const prompt = `You are MCCO-014 "Quality Shield" — Fleet Inspection & Quality Assurance Commander, enhanced with the Peak Performance Frameworks knowledge base. Ferrari-Standard execution, Sovereign governance.
+
+Build a comprehensive productivity optimization plan for ${division ? `the ${division} division` : 'the entire 382-agent fleet'} at Coastal Key Property Management.
+
+## Available Productivity Frameworks:
+
+### 8 Hours in 4 Hours:
+${JSON.stringify(PRODUCTIVITY_8_IN_4.strategies, null, 2)}
+
+### Productivity Techniques:
+${JSON.stringify(PRODUCTIVITY_TECHNIQUES.techniques, null, 2)}
+
+### Flow State Framework:
+${JSON.stringify(FLOW_STATE_FRAMEWORK.outcomes, null, 2)}
+
+### P.A.R.A. Organizational Method:
+${JSON.stringify(PARA_METHOD.components, null, 2)}
+
+### Eisenhower Matrix:
+${JSON.stringify(PRODUCTIVITY_TECHNIQUES.techniques.find(t => t.name === 'Eisenhower Matrix'), null, 2)}
+
+## Target: ${division || 'All Divisions'} | Role: ${role}
+${goals.length > 0 ? `## Specific Goals: ${goals.join(', ')}` : ''}
+
+## Context:
+Coastal Key fleet: 15 MCCO, 20 EXC, 40 SEN, 45 OPS, 30 INT, 47 MKT, 25 FIN, 25 VEN, 25 TEC, 40 WEB agents.
+
+## Deliver:
+
+1. **Daily Operations Schedule** — Optimal time-blocked daily routine using Time Blocking + Pomodoro
+2. **Task Prioritization Matrix** — Eisenhower Matrix applied to division-specific tasks
+3. **Eat the Frog Assignments** — Top 3 high-impact tasks that should be done first each day
+4. **3/3/3 Daily Structure** — 3 deep work items, 3 urgent tasks, 3 maintenance items
+5. **Streak Tracking (Seinfeld)** — Key daily habits that must never be broken
+6. **P.A.R.A. Knowledge Organization** — How the division should organize its intelligence
+7. **Flow State Triggers** — Specific conditions that will put agents into flow state
+8. **Parkinson's Law SLAs** — Aggressive but achievable time limits for key tasks
+9. **Ferrari Score Targets** — Productivity KPIs tied to the Ferrari-Standard quality benchmark
+10. **Weekly Review Cadence** — How to review and optimize the system weekly
+
+Return as structured JSON.`;
+
+  try {
+    const response = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'x-api-key': env.ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: 'claude-opus-4-6',
+        max_tokens: 8000,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    const data = await response.json();
+    const content = data.content?.[0]?.text || '';
+
+    writeAudit(env, ctx, {
+      route: '/v1/frameworks/productivity-plan',
+      action: 'productivity-plan-generated',
+      agent: 'MCCO-014',
+      division: division || 'all',
+      role,
+    });
+
+    return jsonResponse({
+      generatedBy: 'MCCO-014 — Quality Shield + Peak Performance Frameworks',
+      governance: 'sovereign',
+      executionStandard: 'ferrari',
+      division: division || 'all',
+      role,
+      frameworksApplied: [
+        { id: 'FW-004', name: PRODUCTIVITY_8_IN_4.name },
+        { id: 'FW-006', name: PRODUCTIVITY_TECHNIQUES.name },
+        { id: 'FW-005', name: FLOW_STATE_FRAMEWORK.name },
+        { id: 'FW-002', name: PARA_METHOD.name },
+      ],
+      productivityPlan: content,
+      timestamp: new Date().toISOString(),
+    });
+  } catch (err) {
+    return errorResponse(`Productivity plan generation failed: ${err.message}`, 500);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 6 structured knowledge base frameworks (Dan Koe Get Ahead, P.A.R.A. Method, Steve Jobs Sales Rules, 8-in-4 Productivity, Flow State, Productivity Techniques Toolkit) with property management applications
- Adds 7 new API endpoints under `/v1/frameworks/` for listing, filtering, AI-applying frameworks to scenarios, generating content, sales playbooks, and productivity plans
- Integrates with MCCO sovereign intelligence (MCCO-005, MCCO-009, MCCO-014) for AI-powered framework application

## Test plan
- [x] All existing tests pass (`npm test` — 5/5)
- [ ] Verify `GET /v1/frameworks` returns all 6 frameworks
- [ ] Verify `GET /v1/frameworks/FW-003` returns Steve Jobs rules
- [ ] Verify `POST /v1/frameworks/sales-playbook` generates playbook via Claude
- [ ] Verify `POST /v1/frameworks/productivity-plan` generates plan via Claude

https://claude.ai/code/session_01L1YbyiNmsRwJiqVLXX8uqg