### PR TITLE
Replace website with Manus site via production reverse proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Monorepo with Cloudflare Workers, Cloudflare Pages, Airtable, Retell AI, Slack, 
 - **API Gateway**: https://ck-api-gateway.david-e59.workers.dev (49 endpoints)
 - **Sentinel Webhook**: https://sentinel-webhook.david-e59.workers.dev
 - **Nemotron Worker**: https://ck-nemotron-worker.david-e59.workers.dev
-- **Website**: https://main.coastalkey-pm.pages.dev
+- **Website**: https://coastalkey-pm.com (reverse proxy → Manus origin)
 - **Command Center**: https://ck-command-center.pages.dev
 - **Gazette**: Available at `/gazette.html` on Command Center deployment
 
@@ -27,7 +27,7 @@ Monorepo with Cloudflare Workers, Cloudflare Pages, Airtable, Retell AI, Slack, 
 - **ck-api-gateway**: Central API — 90+ endpoints: inference, leads, agents, workflows, pricing, property intel, campaign, email, intelligence officers, MCCO sovereign command, financial engine, analysis suite, trading engine, agent hierarchy, Slack integration (Cloudflare Worker)
 - **ck-nemotron-worker**: NVIDIA Nemotron inference endpoint — `/v1/inference`, `/v1/health` (Cloudflare Worker)
 - **ck-command-center**: Dashboard UI for 312-agent fleet + Coastal Key Gazette (Cloudflare Pages)
-- **ck-website**: Public-facing website with contact form (Cloudflare Pages)
+- **ck-website**: Reverse proxy to Manus production site — _worker.js proxies coastalkey-awfopuqz.manus.space on coastalkey-pm.com domain with edge caching, SEO injection, URL rewriting (Cloudflare Pages)
 - **sentinel-webhook**: Retell call_analyzed → Airtable + Slack pipeline (Cloudflare Worker)
 - **th-sentinel-campaign**: Campaign config, Retell prompts, Airtable field reference
 

--- a/ck-website/_headers
+++ b/ck-website/_headers
@@ -1,9 +1,13 @@
 # ══════════════════════════════════════════════════════════════════════════
-# Coastal Key — Cloudflare Pages Security Headers
-# Most headers handled by _worker.js reverse proxy
+# Coastal Key — Cloudflare Pages Headers
+# Primary security headers set by _worker.js; these are baseline fallbacks.
 # ══════════════════════════════════════════════════════════════════════════
 
 /*
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains
+
+/index.html
+  Cache-Control: no-cache

--- a/ck-website/_redirects
+++ b/ck-website/_redirects
@@ -1,10 +1,11 @@
 # ══════════════════════════════════════════════════════════════════════════
 # Coastal Key — Cloudflare Pages Redirects
-# Subdomain consolidation — all subdomains redirect to primary domain
-# Main site content served via _worker.js reverse proxy to Manus
+#
+# Subdomain consolidation to primary domain.
+# All site content served via _worker.js reverse proxy to Manus origin.
 # ══════════════════════════════════════════════════════════════════════════
 
-# ── Subdomain consolidation (all point to primary domain) ──
+# ── Subdomain consolidation ──
 https://www.coastalkey-pm.com/*       https://coastalkey-pm.com/:splat      301
 https://app.coastalkey-pm.com/*       https://coastalkey-pm.com/:splat      301
 https://dashboard.coastalkey-pm.com/* https://coastalkey-pm.com/:splat      301

--- a/ck-website/_worker.js
+++ b/ck-website/_worker.js
@@ -1,34 +1,172 @@
 // ══════════════════════════════════════════════════════════════════════════
-// Coastal Key Website — Reverse Proxy to Manus Site
+// Coastal Key Property Management — Production Reverse Proxy
 //
-// Proxies all requests from coastalkey-pm.com to the Manus-hosted website
-// while keeping the coastalkey-pm.com domain in the browser URL bar.
+// Serves the Manus-hosted website (coastalkey-awfopuqz.manus.space) on
+// the coastalkey-pm.com domain via Cloudflare Pages Worker.
+//
+// Features:
+//   - Full URL rewriting across HTML, CSS, JS responses
+//   - Edge caching for static assets (images, fonts, CSS, JS)
+//   - SEO canonical injection for search engine alignment
+//   - Retry with backoff on upstream failures
+//   - Custom robots.txt serving the canonical domain
+//   - Graceful fallback on origin downtime
 // ══════════════════════════════════════════════════════════════════════════
 
 const MANUS_ORIGIN = 'https://coastalkey-awfopuqz.manus.space';
 const MANUS_HOST = 'coastalkey-awfopuqz.manus.space';
+const CANONICAL_DOMAIN = 'coastalkey-pm.com';
+const CANONICAL_ORIGIN = 'https://coastalkey-pm.com';
+
+// Cache TTLs (seconds)
+const CACHE_HTML = 300;         // 5 min — pages refresh quickly
+const CACHE_STATIC = 2592000;   // 30 days — versioned assets
+const CACHE_FONT = 31536000;    // 1 year — fonts never change
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function isStaticAsset(pathname) {
+  return /\.(css|js|png|jpg|jpeg|gif|svg|ico|webp|avif|woff|woff2|ttf|eot|otf|mp4|webm|pdf)(\?.*)?$/i.test(pathname);
+}
+
+function getCacheTTL(pathname, contentType) {
+  if (/\.(woff2?|ttf|eot|otf)(\?.*)?$/i.test(pathname)) return CACHE_FONT;
+  if (isStaticAsset(pathname)) return CACHE_STATIC;
+  if (contentType?.includes('text/html')) return CACHE_HTML;
+  return CACHE_HTML;
+}
+
+function isTextContent(contentType) {
+  if (!contentType) return false;
+  return contentType.includes('text/html')
+    || contentType.includes('text/css')
+    || contentType.includes('javascript')
+    || contentType.includes('application/json')
+    || contentType.includes('text/xml')
+    || contentType.includes('application/xml');
+}
+
+function rewriteUrls(body, siteOrigin, siteHost) {
+  return body
+    .replaceAll(MANUS_ORIGIN, siteOrigin)
+    .replaceAll(`//${MANUS_HOST}`, `//${siteHost}`)
+    .replaceAll(`"${MANUS_HOST}"`, `"${siteHost}"`)
+    .replaceAll(`'${MANUS_HOST}'`, `'${siteHost}'`)
+    .replaceAll(MANUS_HOST, siteHost);
+}
+
+function injectSEO(html, pathname, siteOrigin) {
+  const canonicalUrl = siteOrigin + pathname;
+  const canonicalTag = `<link rel="canonical" href="${canonicalUrl}">`;
+
+  // Inject canonical if not already present
+  if (!html.includes('rel="canonical"')) {
+    html = html.replace('</head>', `  ${canonicalTag}\n</head>`);
+  } else {
+    // Replace any manus canonical with ours
+    html = html.replace(
+      /(<link\s+rel="canonical"\s+href=")([^"]*)(">)/i,
+      `$1${canonicalUrl}$3`
+    );
+  }
+
+  // Inject/fix og:url
+  if (html.includes('og:url')) {
+    html = html.replace(
+      /(<meta\s+property="og:url"\s+content=")([^"]*)(">)/i,
+      `$1${canonicalUrl}$3`
+    );
+  }
+
+  return html;
+}
+
+async function fetchWithRetry(url, options, retries = 2) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, options);
+      if (response.status >= 500 && attempt < retries) {
+        await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+        continue;
+      }
+      return response;
+    } catch (err) {
+      if (attempt === retries) throw err;
+      await new Promise(r => setTimeout(r, 500 * (attempt + 1)));
+    }
+  }
+}
+
+// ── Custom Responses ─────────────────────────────────────────────────────
+
+function robotsTxt() {
+  return new Response(
+    `User-agent: *\nAllow: /\nSitemap: ${CANONICAL_ORIGIN}/sitemap.xml\n\nHost: ${CANONICAL_DOMAIN}\n`,
+    { headers: { 'Content-Type': 'text/plain', 'Cache-Control': 'public, max-age=86400' } }
+  );
+}
+
+function maintenancePage() {
+  return new Response(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Coastal Key Property Management</title>
+  <style>
+    *{margin:0;padding:0;box-sizing:border-box}
+    body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;min-height:100vh;display:flex;align-items:center;justify-content:center;background:linear-gradient(135deg,#0a1628 0%,#1a2942 50%,#0d1f3c 100%);color:#e2e8f0}
+    .card{text-align:center;max-width:480px;padding:3rem 2rem;background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:16px;backdrop-filter:blur(20px)}
+    .logo{font-size:2rem;font-weight:700;background:linear-gradient(135deg,#60a5fa,#38bdf8);-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:.5rem}
+    .sub{color:#94a3b8;font-size:.95rem;line-height:1.6;margin-bottom:1.5rem}
+    .contact{font-size:.85rem;color:#64748b}
+    .contact a{color:#60a5fa;text-decoration:none}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="logo">Coastal Key</div>
+    <p class="sub">We're upgrading our systems to serve you better.<br>Please check back in a few minutes.</p>
+    <p class="contact">Questions? <a href="mailto:david@coastalkey-pm.com">david@coastalkey-pm.com</a> | <a href="tel:+17722103343">(772) 210-3343</a></p>
+  </div>
+</body>
+</html>`, {
+    status: 503,
+    headers: {
+      'Content-Type': 'text/html;charset=UTF-8',
+      'Retry-After': '120',
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+// ── Main Handler ─────────────────────────────────────────────────────────
 
 export default {
-  async fetch(request, env) {
+  async fetch(request, env, ctx) {
     const url = new URL(request.url);
     const siteOrigin = url.origin;
     const siteHost = url.hostname;
 
-    // Build target URL on Manus
+    // Serve our own robots.txt for the canonical domain
+    if (url.pathname === '/robots.txt') return robotsTxt();
+
+    // Build target URL
     const targetUrl = MANUS_ORIGIN + url.pathname + url.search;
 
-    // Forward headers, replacing host
+    // Prepare forwarded headers
     const proxyHeaders = new Headers(request.headers);
     proxyHeaders.set('Host', MANUS_HOST);
     proxyHeaders.set('X-Forwarded-Host', siteHost);
     proxyHeaders.set('X-Forwarded-Proto', 'https');
-    proxyHeaders.delete('cf-connecting-ip');
-    proxyHeaders.delete('cf-ray');
-    proxyHeaders.delete('cf-visitor');
-    proxyHeaders.delete('cf-ipcountry');
+    proxyHeaders.set('X-Real-IP', request.headers.get('cf-connecting-ip') || '');
+    // Strip Cloudflare-specific headers that confuse upstream
+    for (const h of ['cf-connecting-ip', 'cf-ray', 'cf-visitor', 'cf-ipcountry', 'cf-warp-tag-id']) {
+      proxyHeaders.delete(h);
+    }
 
     try {
-      const response = await fetch(targetUrl, {
+      const response = await fetchWithRetry(targetUrl, {
         method: request.method,
         headers: proxyHeaders,
         body: request.method !== 'GET' && request.method !== 'HEAD' ? request.body : undefined,
@@ -37,33 +175,58 @@ export default {
 
       const responseHeaders = new Headers(response.headers);
 
-      // Rewrite redirect locations to keep users on our domain
+      // Rewrite Location headers for redirects
       const location = responseHeaders.get('location');
       if (location) {
-        responseHeaders.set(
-          'location',
-          location
-            .replace(MANUS_ORIGIN, siteOrigin)
-            .replace(`//${MANUS_HOST}`, `//${siteHost}`)
+        responseHeaders.set('location',
+          location.replaceAll(MANUS_ORIGIN, siteOrigin).replaceAll(MANUS_HOST, siteHost)
         );
       }
 
-      // Remove headers that conflict with our domain
+      // Rewrite Set-Cookie domains
+      const cookies = responseHeaders.getAll?.('set-cookie') || [];
+      if (cookies.length) {
+        responseHeaders.delete('set-cookie');
+        for (const cookie of cookies) {
+          responseHeaders.append('set-cookie',
+            cookie.replaceAll(MANUS_HOST, siteHost)
+          );
+        }
+      }
+
+      // Strip upstream security headers we'll replace
       responseHeaders.delete('x-frame-options');
       responseHeaders.delete('content-security-policy');
+      responseHeaders.delete('strict-transport-security');
 
-      // Set our own security headers
+      // Set production security headers
       responseHeaders.set('X-Content-Type-Options', 'nosniff');
       responseHeaders.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+      responseHeaders.set('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+      responseHeaders.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
 
+      // Set cache control
       const contentType = responseHeaders.get('content-type') || '';
+      const ttl = getCacheTTL(url.pathname, contentType);
+      if (isStaticAsset(url.pathname)) {
+        responseHeaders.set('Cache-Control', `public, max-age=${ttl}, immutable`);
+      } else if (contentType.includes('text/html')) {
+        responseHeaders.set('Cache-Control', `public, max-age=${CACHE_HTML}, s-maxage=${CACHE_HTML}, stale-while-revalidate=60`);
+      }
 
-      // For HTML responses, rewrite Manus URLs to our domain
-      if (contentType.includes('text/html')) {
+      // For text content, rewrite URLs
+      if (isTextContent(contentType)) {
         let body = await response.text();
-        body = body.replaceAll(MANUS_ORIGIN, siteOrigin);
-        body = body.replaceAll(`//${MANUS_HOST}`, `//${siteHost}`);
-        body = body.replaceAll(MANUS_HOST, siteHost);
+        body = rewriteUrls(body, siteOrigin, siteHost);
+
+        // Inject SEO for HTML
+        if (contentType.includes('text/html')) {
+          body = injectSEO(body, url.pathname, siteOrigin);
+        }
+
+        // Correct content-length after rewriting
+        responseHeaders.delete('content-length');
+        responseHeaders.delete('content-encoding');
 
         return new Response(body, {
           status: response.status,
@@ -72,66 +235,15 @@ export default {
         });
       }
 
-      // For CSS responses, rewrite any absolute Manus URLs
-      if (contentType.includes('text/css')) {
-        let body = await response.text();
-        body = body.replaceAll(MANUS_ORIGIN, siteOrigin);
-        body = body.replaceAll(MANUS_HOST, siteHost);
-
-        return new Response(body, {
-          status: response.status,
-          statusText: response.statusText,
-          headers: responseHeaders,
-        });
-      }
-
-      // For JS responses, rewrite any absolute Manus URLs
-      if (contentType.includes('javascript')) {
-        let body = await response.text();
-        body = body.replaceAll(MANUS_ORIGIN, siteOrigin);
-        body = body.replaceAll(MANUS_HOST, siteHost);
-
-        return new Response(body, {
-          status: response.status,
-          statusText: response.statusText,
-          headers: responseHeaders,
-        });
-      }
-
-      // All other content types (images, fonts, etc.) pass through as-is
+      // Binary assets pass through
       return new Response(response.body, {
         status: response.status,
         statusText: response.statusText,
         headers: responseHeaders,
       });
+
     } catch (err) {
-      // If Manus origin is unreachable, show a maintenance page
-      return new Response(
-        `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Coastal Key Property Management</title>
-  <style>
-    body { font-family: system-ui, -apple-system, sans-serif; display: flex; align-items: center; justify-content: center; min-height: 100vh; margin: 0; background: #0a1628; color: #e2e8f0; }
-    .container { text-align: center; max-width: 500px; padding: 2rem; }
-    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
-    p { color: #94a3b8; }
-  </style>
-</head>
-<body>
-  <div class="container">
-    <h1>Coastal Key Property Management</h1>
-    <p>We're performing scheduled maintenance. Please check back shortly.</p>
-  </div>
-</body>
-</html>`,
-        {
-          status: 503,
-          headers: { 'Content-Type': 'text/html;charset=UTF-8', 'Retry-After': '60' },
-        }
-      );
+      return maintenancePage();
     }
   },
 };

--- a/ck-website/index.html
+++ b/ck-website/index.html
@@ -3,20 +3,26 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Coastal Key Property Management — Treasure Coast Luxury Management</title>
-  <meta name="description" content="AI-powered luxury property management on Florida's Treasure Coast. Serving Vero Beach, Stuart, Jupiter, and surrounding areas.">
+  <title>Coastal Key Property Management — AI-Powered Luxury Property Management | Treasure Coast FL</title>
+  <meta name="description" content="AI-powered luxury property management on Florida's Treasure Coast. 382 AI agents delivering white-glove service — Home Watch, Asset Management, Storm Protection, and Concierge Services from Vero Beach to Jupiter.">
+  <meta name="keywords" content="property management, Treasure Coast, Vero Beach, Stuart, Jupiter, luxury, AI, Florida, home watch, asset management, storm protection">
   <meta property="og:title" content="Coastal Key Property Management">
-  <meta property="og:description" content="AI-powered luxury property management on Florida's Treasure Coast.">
+  <meta property="og:description" content="AI-powered luxury property management on Florida's Treasure Coast. Home Watch, Asset Management, Storm Protection, and Concierge Services.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://coastalkey-pm.com">
+  <meta property="og:site_name" content="Coastal Key Property Management">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Coastal Key Property Management">
+  <meta name="twitter:description" content="AI-powered luxury property management on Florida's Treasure Coast.">
   <link rel="canonical" href="https://coastalkey-pm.com">
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "LocalBusiness",
     "name": "Coastal Key Property Management",
-    "description": "AI-powered luxury property management on Florida's Treasure Coast.",
+    "description": "AI-powered luxury property management on Florida's Treasure Coast. Home Watch, Asset Management, Storm Protection, and Concierge Services.",
     "url": "https://coastalkey-pm.com",
+    "telephone": "+1-772-210-3343",
     "email": "david@coastalkey-pm.com",
     "address": {
       "@type": "PostalAddress",
@@ -32,14 +38,39 @@
       { "@type": "City", "name": "Jensen Beach" },
       { "@type": "City", "name": "Palm City" },
       { "@type": "City", "name": "Stuart" },
-      { "@type": "City", "name": "Hutchinson Island" }
+      { "@type": "City", "name": "Hutchinson Island" },
+      { "@type": "City", "name": "Jupiter" }
+    ],
+    "openingHours": "Mo-Su 00:00-23:59",
+    "@graph": [
+      {
+        "@type": "WebSite",
+        "url": "https://coastalkey-pm.com",
+        "name": "Coastal Key Property Management"
+      },
+      {
+        "@type": "Service",
+        "serviceType": "Property Management",
+        "provider": { "@type": "LocalBusiness", "name": "Coastal Key Property Management" },
+        "areaServed": { "@type": "State", "name": "Florida" },
+        "hasOfferCatalog": {
+          "@type": "OfferCatalog",
+          "name": "Property Management Services",
+          "itemListElement": [
+            { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Home Watch", "description": "Comprehensive property monitoring for seasonal and absentee homeowners" }},
+            { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Asset Management", "description": "Full-service investment property and asset management" }},
+            { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Storm Protection", "description": "Hurricane preparation, monitoring, and post-storm recovery services" }},
+            { "@type": "Offer", "itemOffered": { "@type": "Service", "name": "Concierge Services", "description": "White-glove property concierge for luxury homeowners" }}
+          ]
+        }
+      }
     ]
   }
   </script>
 </head>
 <body>
   <noscript>
-    <meta http-equiv="refresh" content="0;url=https://coastalkey-awfopuqz.manus.space/">
+    <p>Coastal Key Property Management — AI-Powered Luxury Property Management on Florida's Treasure Coast. Call (772) 210-3343 or email david@coastalkey-pm.com.</p>
   </noscript>
 </body>
 </html>

--- a/ck-website/wrangler.toml
+++ b/ck-website/wrangler.toml
@@ -1,10 +1,11 @@
 # ══════════════════════════════════════════════════════════════════════════
 # Coastal Key Website — Cloudflare Pages Configuration
 #
-# Architecture: _worker.js reverse proxy to Manus-hosted site
+# Architecture: _worker.js reverse proxy to Manus-hosted production site
 # Origin: https://coastalkey-awfopuqz.manus.space
+# Domain: coastalkey-pm.com
+#
 # Deploy: wrangler pages deploy ./ck-website --project-name=coastalkey-pm
-# Domain: coastalkey-pm.com (all subdomains redirect here)
 # ══════════════════════════════════════════════════════════════════════════
 
 name = "coastalkey-pm"

--- a/deployment.json
+++ b/deployment.json
@@ -2,16 +2,39 @@
   "project": "coastalkey-pm",
   "domain": "coastalkey-pm.com",
   "architecture": {
-    "website": "Cloudflare Pages (ck-website/ — reverse proxy to Manus)",
+    "website": "Cloudflare Pages _worker.js reverse proxy → Manus origin (coastalkey-awfopuqz.manus.space)",
     "api": "Cloudflare Workers (ck-api-gateway/)",
     "nemotron": "Cloudflare Workers (ck-nemotron-worker/)",
     "webhook": "Cloudflare Workers (sentinel-webhook/)",
     "dashboard": "Cloudflare Pages (ck-command-center/)"
   },
+  "website_proxy": {
+    "origin": "https://coastalkey-awfopuqz.manus.space",
+    "domain": "coastalkey-pm.com",
+    "features": [
+      "URL rewriting (HTML, CSS, JS, JSON)",
+      "Edge caching (static 30d, fonts 1y, HTML 5m)",
+      "SEO canonical injection",
+      "Retry with backoff on upstream failures",
+      "Custom robots.txt for canonical domain",
+      "HSTS + security headers",
+      "Set-Cookie domain rewriting",
+      "Graceful 503 maintenance fallback"
+    ],
+    "pages": [
+      "/",
+      "/services",
+      "/agents",
+      "/dashboard",
+      "/eliza",
+      "/portal",
+      "/admin"
+    ]
+  },
   "deployment": {
     "website": {
       "steps": [
-        { "step": 1, "action": "Deploy website to Cloudflare Pages", "command": "wrangler pages deploy ./ck-website --project-name=coastalkey-pm" },
+        { "step": 1, "action": "Deploy reverse proxy to Cloudflare Pages", "command": "wrangler pages deploy ./ck-website --project-name=coastalkey-pm" },
         { "step": 2, "action": "Purge Cloudflare cache", "command": "curl -X POST 'https://api.cloudflare.com/client/v4/zones/{zone_id}/purge_cache' -H 'Authorization: Bearer {token}' -d '{\"purge_everything\":true}'" }
       ]
     },
@@ -39,11 +62,10 @@
   "subdomain_consolidation": {
     "policy": "All subdomains redirect to coastalkey-pm.com via _redirects",
     "eliminated": ["www", "app", "dashboard", "agents", "api", "admin", "old", "staging", "dev", "beta"],
-    "active_domain": "coastalkey-pm.com",
-    "portal_path": "/portal"
+    "active_domain": "coastalkey-pm.com"
   },
   "agents": {
-    "total": 290,
+    "total": 382,
     "divisions": 9,
     "web_dev_agents": 40
   }


### PR DESCRIPTION
## Summary

- **Removes** the old vanilla JS SPA website entirely (router, auth, API client, components, styles)
- **Replaces** it with a production-grade Cloudflare Pages `_worker.js` reverse proxy that serves the Manus website (`coastalkey-awfopuqz.manus.space`) on the `coastalkey-pm.com` domain
- **Adds** automated website deployment to the CI/CD pipeline (was previously missing)

## What the Proxy Does

| Feature | Detail |
|---|---|
| **URL Rewriting** | Rewrites Manus URLs to coastalkey-pm.com across HTML, CSS, JS, JSON, XML |
| **Edge Caching** | Static assets 30 days, fonts 1 year, HTML 5 min with stale-while-revalidate |
| **SEO Injection** | Canonical URLs and og:url rewritten to coastalkey-pm.com on every page |
| **Retry + Backoff** | 2 retries with 500ms/1s delay on upstream 5xx or network errors |
| **Security** | HSTS, nosniff, referrer-policy, permissions-policy on all responses |
| **Cookie Rewriting** | Set-Cookie domains translated to our domain |
| **robots.txt** | Custom robots.txt serving canonical domain sitemap |
| **Fallback** | Branded 503 maintenance page with contact info on origin downtime |

## Why This Architecture

The Manus site is the newer, more feature-rich version with AI Command Center, CEO Dashboard, ELIZA, Client Portal, and Admin pages. The old SPA was a simpler marketing site. The reverse proxy approach means:
- Manus continues to host and update the site content
- `coastalkey-pm.com` stays as the canonical domain in browsers and search engines
- No content duplication or manual sync needed
- Edge caching via Cloudflare for performance

## Files Changed

- `ck-website/_worker.js` — New production reverse proxy (core change)
- `ck-website/index.html` — SEO fallback with Schema.org structured data
- `ck-website/_headers` — Baseline security headers
- `ck-website/_redirects` — Subdomain consolidation only
- `ck-website/wrangler.toml` — Updated config comments
- `ck-website/src/` — **Deleted** (old SPA: app.js, main.js, main.css, router.js, api.js, auth.js)
- `.github/workflows/deploy.yml` — Added `deploy-website` job
- `deployment.json` — Updated architecture and proxy feature inventory
- `CLAUDE.md` — Updated live endpoints and architecture description

## Test Plan

- [ ] Merge to main triggers CI/CD `deploy-website` job successfully
- [ ] `coastalkey-pm.com` serves the Manus website content
- [ ] URL bar shows `coastalkey-pm.com` (not manus.space)
- [ ] Internal links (AI Command Center, Services, CEO Dashboard, ELIZA) work
- [ ] Contact form submissions forward correctly
- [ ] `www.coastalkey-pm.com` redirects to `coastalkey-pm.com`
- [ ] `coastalkey-pm.com/robots.txt` serves canonical sitemap
- [ ] Static assets (images, CSS, JS) load with cache headers
- [ ] 503 maintenance page shows if Manus origin is down

https://claude.ai/code/session_0121QBQV5jepKAPMVFfeRDQr