### PR TITLE
Re-fire disable-nemotron-builds workflow

### DIFF
--- a/.github/workflows/disable-nemotron-builds.yml
+++ b/.github/workflows/disable-nemotron-builds.yml
@@ -4,6 +4,7 @@ name: Disable Nemotron Workers Builds
 # Disables the Cloudflare Workers Builds Git integration for ck-nemotron-worker
 # which causes false-negative 500 check runs on every commit.
 # GitHub Actions CI/CD (deploy.yml) is the authoritative deploy system.
+# Re-fire 2026-04-30 — retry programmatic disable in secrets-having env (Coastal Key AI CEO directive).
 
 on:
   push:


### PR DESCRIPTION
## Summary

Touches `.github/workflows/disable-nemotron-builds.yml` (one comment line) to retrigger the paths-watched workflow on merge to main. Runs `scripts/disable-nemotron-builds.sh` in the GitHub Actions environment where `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` are available as secrets.

## Why

The `Workers Builds: ck-nemotron-worker` false-negative still fires on every PR push. PR #31 shipped the operator README documenting the dashboard-disconnect remediation. This PR re-fires the programmatic disable script per Coastal Key AI CEO directive — exhaust automated paths before relying on the dashboard click.

The script attempts four Cloudflare API endpoints:
1. `PATCH /workers/scripts/{name}/builds`
2. `DELETE /workers/services/{name}/environments/production/builds/config`
3. `PATCH /workers/services/{name}/environments/production` with `build_config.enabled: false`
4. `wrangler builds configure --disable`

Previous runs returned 404 / no-op on all four. Cloudflare's API surface may have evolved; this rerun verifies. If still 404 across the board, the dashboard click remains the sole remaining lever.

## Test Plan

- [ ] Merge to main
- [ ] Workflow `Disable Nemotron Workers Builds` fires automatically (paths watcher)
- [ ] Inspect logs for endpoint responses
- [ ] If any endpoint returns 200/204 → false-negative permanently resolved on next PR push
- [ ] If all 404 → escalate to dashboard click per `ck-nemotron-worker/README.md`

## Risk

Zero. This is a pure trigger PR — no functional code change, only a comment line in a workflow that is otherwise idle until triggered.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Spv66hWnY419nU7fJp6qx4)_