### PR TITLE
Restore ck-trading-desk workspace integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "workspaces": [
     "ck-api-gateway",
     "sentinel-webhook",
-    "ck-nemotron-worker"
+    "ck-nemotron-worker",
+    "ck-trading-desk"
   ],
   "scripts": {
     "prestart": "node scripts/init-data.js",
@@ -20,6 +21,8 @@
     "dev:gateway": "cd ck-api-gateway && npm run dev",
     "dev:sentinel": "cd sentinel-webhook && npm run dev",
     "dev:nemotron": "cd ck-nemotron-worker && npm run dev",
+    "dev:trading": "cd ck-trading-desk && npm run dev",
+    "build:trading": "cd ck-trading-desk && npm run build",
     "deploy": "npm run deploy:gateway && npm run deploy:sentinel && npm run deploy:cc && npm run deploy:nemotron",
     "deploy:gateway": "cd ck-api-gateway && npm run deploy",
     "deploy:sentinel": "cd sentinel-webhook && npm run deploy",


### PR DESCRIPTION
## Summary

Conversation audit fix: `ck-trading-desk` was dropped from the `package.json` workspaces array during subsequent merges from other sessions.

- Restored `ck-trading-desk` to workspaces array
- Added `dev:trading` and `build:trading` npm scripts

All 6 session deliverables verified complete on main:
1. CK Trading Desk — SHIPPED
2. Thinking Coach / Frameworks — SHIPPED
3. Client Website + Payments + Calendar — SHIPPED
4. Cloudflare Deployment Fixes — SHIPPED
5. Slack Integration — SHIPPED
6. ElevenLabs Voice Clone Prompt — SHIPPED

## Test plan
- [x] All existing tests unaffected (workspace addition only)
- [x] `npm run dev:trading` and `npm run build:trading` scripts resolve correctly

https://claude.ai/code/session_01UBUqoaLn5vydFzLvPZot7D

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBUqoaLn5vydFzLvPZot7D)_