### PR TITLE
Extend smoke-test: verify website + command-center liveness

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -218,6 +218,8 @@ jobs:
           GATEWAY_URL="https://ck-api-gateway.david-e59.workers.dev"
           NEMOTRON_URL="https://ck-nemotron-worker.david-e59.workers.dev"
           SENTINEL_URL="https://sentinel-webhook.david-e59.workers.dev"
+          WEBSITE_URL="https://coastalkey-pm.com"
+          CC_URL="https://ck-command-center.pages.dev"
 
           # Allow Cloudflare a moment to propagate after wrangler deploy
           sleep 20
@@ -226,6 +228,8 @@ jobs:
           GATEWAY_DASH=$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" "$GATEWAY_URL/v1/orchestrator/dashboard" || echo "fail")
           NEMOTRON_HEALTH=$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" "$NEMOTRON_URL/v1/health" || echo "fail")
           SENTINEL_HEALTH=$(curl -sS --max-time 10 -o /dev/null -w "%{http_code}" "$SENTINEL_URL/" || echo "fail")
+          WEBSITE_HEALTH=$(curl -sS --max-time 15 -L -o /dev/null -w "%{http_code}" "$WEBSITE_URL/" || echo "fail")
+          CC_HEALTH=$(curl -sS --max-time 15 -L -o /dev/null -w "%{http_code}" "$CC_URL/" || echo "fail")
 
           # Liveness: any HTTP response (200, 302, 401, 405) proves worker is reachable
           GATEWAY_ALIVE="false"
@@ -233,6 +237,11 @@ jobs:
           # Dashboard returning 401 means route exists and auth gate works = code is deployed
           GATEWAY_AUTH_ENFORCED="false"
           if [ "$GATEWAY_DASH" = "401" ]; then GATEWAY_AUTH_ENFORCED="true"; fi
+          # Pages liveness: 200 (or any 2xx/3xx) means deployed and reachable
+          WEBSITE_ALIVE="false"
+          if [ "$WEBSITE_HEALTH" != "fail" ] && [ "$WEBSITE_HEALTH" != "000" ] && [ "${WEBSITE_HEALTH:0:1}" != "5" ]; then WEBSITE_ALIVE="true"; fi
+          CC_ALIVE="false"
+          if [ "$CC_HEALTH" != "fail" ] && [ "$CC_HEALTH" != "000" ] && [ "${CC_HEALTH:0:1}" != "5" ]; then CC_ALIVE="true"; fi
 
           echo "gateway_health=$GATEWAY_HEALTH" >> "$GITHUB_OUTPUT"
           echo "gateway_dash=$GATEWAY_DASH" >> "$GITHUB_OUTPUT"
@@ -240,6 +249,10 @@ jobs:
           echo "gateway_auth_enforced=$GATEWAY_AUTH_ENFORCED" >> "$GITHUB_OUTPUT"
           echo "nemotron_health=$NEMOTRON_HEALTH" >> "$GITHUB_OUTPUT"
           echo "sentinel_health=$SENTINEL_HEALTH" >> "$GITHUB_OUTPUT"
+          echo "website_health=$WEBSITE_HEALTH" >> "$GITHUB_OUTPUT"
+          echo "website_alive=$WEBSITE_ALIVE" >> "$GITHUB_OUTPUT"
+          echo "cc_health=$CC_HEALTH" >> "$GITHUB_OUTPUT"
+          echo "cc_alive=$CC_ALIVE" >> "$GITHUB_OUTPUT"
 
       - name: Write deploy-status.json
         run: |
@@ -266,6 +279,16 @@ jobs:
               "sentinel": {
                 "url": "https://sentinel-webhook.david-e59.workers.dev",
                 "healthHttpStatus": "${{ steps.probe.outputs.sentinel_health }}"
+              },
+              "website": {
+                "url": "https://coastalkey-pm.com",
+                "alive": ${{ steps.probe.outputs.website_alive }},
+                "httpStatus": "${{ steps.probe.outputs.website_health }}"
+              },
+              "commandCenter": {
+                "url": "https://ck-command-center.pages.dev",
+                "alive": ${{ steps.probe.outputs.cc_alive }},
+                "httpStatus": "${{ steps.probe.outputs.cc_health }}"
               }
             }
           }


### PR DESCRIPTION
## Summary

Closes the verification gap on the two Pages deploys. Previously `deploy-status.json` only reported on 3 of the 5 deployed services (gateway, nemotron, sentinel). After this change, every push to main also confirms:

- **`coastalkey-pm.com`** — website (reverse-proxied via `_worker.js` to Manus origin)
- **`ck-command-center.pages.dev`** — command center dashboard + Gazette

## Change

In the `smoke-test` job:
1. Add `WEBSITE_URL` and `CC_URL` to the probe
2. Add `curl` checks for both with 15s timeout and follow-redirect
3. Compute `*_ALIVE` flags (any 2xx/3xx = alive; 5xx or unreachable = dead)
4. Emit five new step outputs: `website_health`, `website_alive`, `cc_health`, `cc_alive`
5. Extend `deploy-status.json` JSON output with `liveness.website` and `liveness.commandCenter` blocks

## Audit Context

This session's go-live audit identified that the existing smoke-test surface was incomplete:

| Service | Pre-PR | Post-PR |
|---|---|---|
| ck-api-gateway | ✅ verified | ✅ verified |
| ck-nemotron-worker | ✅ verified | ✅ verified |
| sentinel-webhook | ✅ verified | ✅ verified |
| ck-website (coastalkey-pm.com) | ❌ blind | ✅ verified |
| ck-command-center | ❌ blind | ✅ verified |

## Test Plan

- [ ] CI gates pass (`Test`, `Spec build + content policy`)
- [ ] Merge to main → full deploy chain fires
- [ ] Smoke-test job runs after deploys
- [ ] `[skip ci]` commit lands on main with new `liveness.website` + `liveness.commandCenter` keys populated
- [ ] HTTP status codes for both Pages services are 2xx/3xx (alive=true)

## Risk

Low. Workflow-only addition; no existing probes modified. If the new endpoints are unreachable for any reason, `alive: false` is recorded — the job itself does not fail (probes use `set +e`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Spv66hWnY419nU7fJp6qx4)_