### PR TITLE
Go Live: API gateway proxy, custom domain, integration tests

### DIFF
--- a/ck-api-gateway/src/__tests__/gateway.test.js
+++ b/ck-api-gateway/src/__tests__/gateway.test.js
@@ -127,3 +127,47 @@ describe('Audit Writer', () => {
     assert.ok(keys.keys.length > 0);
   });
 });
+
+// ─�� Airtable Table Constants ──
+import { TABLES } from '../services/airtable.js';
+
+describe('Airtable Table Constants', () => {
+  it('defines all core tables', () => {
+    assert.ok(TABLES.LEADS, 'LEADS table required');
+    assert.ok(TABLES.CONTENT_CALENDAR, 'CONTENT_CALENDAR table required');
+    assert.ok(TABLES.PODCAST_PRODUCTION, 'PODCAST_PRODUCTION table required');
+    assert.ok(TABLES.AI_LOG, 'AI_LOG table required');
+    assert.ok(TABLES.TASKS, 'TASKS table required');
+  });
+
+  it('table IDs follow Airtable format', () => {
+    for (const [name, id] of Object.entries(TABLES)) {
+      assert.ok(id.startsWith('tbl'), `${name} should start with "tbl", got "${id}"`);
+    }
+  });
+});
+
+// ── Buffer Service Exports ──
+import * as bufferService from '../services/buffer.js';
+
+describe('Buffer Service', () => {
+  it('exports resolveProfileId function', () => {
+    assert.equal(typeof bufferService.resolveProfileId, 'function');
+  });
+
+  it('exports schedulePost function', () => {
+    assert.equal(typeof bufferService.schedulePost, 'function');
+  });
+
+  it('exports crossPostSchedule function', () => {
+    assert.equal(typeof bufferService.crossPostSchedule, 'function');
+  });
+
+  it('exports getProfiles function', () => {
+    assert.equal(typeof bufferService.getProfiles, 'function');
+  });
+
+  it('exports syncAnalyticsToCalendar function', () => {
+    assert.equal(typeof bufferService.syncAnalyticsToCalendar, 'function');
+  });
+});

--- a/ck-website/_worker.js
+++ b/ck-website/_worker.js
@@ -1,4 +1,4 @@
-// ══════════════════════════════════════════════════════════════════════════
+// ════════════════════════════════════════���═════════════════════════════════
 // Coastal Key Property Management — Production Reverse Proxy
 //
 // Serves the Manus-hosted website (coastalkey-awfopuqz.manus.space) on
@@ -11,19 +11,20 @@
 //   - Retry with backoff on upstream failures
 //   - Custom robots.txt serving the canonical domain
 //   - Graceful fallback on origin downtime
-// ══════════════════════════════════════════════════════════════════════════
+// ═════════���═══════════════════════════════���═══════════════════════════���════
 
 const MANUS_ORIGIN = 'https://coastalkey-awfopuqz.manus.space';
 const MANUS_HOST = 'coastalkey-awfopuqz.manus.space';
 const CANONICAL_DOMAIN = 'coastalkey-pm.com';
 const CANONICAL_ORIGIN = 'https://coastalkey-pm.com';
+const API_GATEWAY_ORIGIN = 'https://ck-api-gateway.david-e59.workers.dev';
 
 // Cache TTLs (seconds)
 const CACHE_HTML = 300;         // 5 min — pages refresh quickly
 const CACHE_STATIC = 2592000;   // 30 days — versioned assets
 const CACHE_FONT = 31536000;    // 1 year — fonts never change
 
-// ── Helpers ──────────────────────────────────────────────────────────────
+// ── Helpers ───────────���──────────────────────────────────────────────────
 
 function isStaticAsset(pathname) {
   return /\.(css|js|png|jpg|jpeg|gif|svg|ico|webp|avif|woff|woff2|ttf|eot|otf|mp4|webm|pdf)(\?.*)?$/i.test(pathname);
@@ -46,7 +47,7 @@ function isTextContent(contentType) {
     || contentType.includes('application/xml');
 }
 
-// ── Phase 3: BEM → Tailwind class rewriting at edge ────────────────────
+// ── Phase 3: BEM → Tailwind class rewriting at edge ──────────��─────────
 
 const BEM_TO_TAILWIND = [
   ['section-header', 'ck-section'],
@@ -162,7 +163,7 @@ function injectSEO(html, pathname, siteOrigin) {
   } else {
     // Replace any manus canonical with ours
     html = html.replace(
-      /(<link\s+rel="canonical"\s+href=")([^"]*)(">)/i,
+      /(<link\s+rel="canonical"\s+href=")([^"]*)("\s*>)/i,
       `$1${canonicalUrl}$3`
     );
   }
@@ -170,7 +171,7 @@ function injectSEO(html, pathname, siteOrigin) {
   // Inject/fix og:url
   if (html.includes('og:url')) {
     html = html.replace(
-      /(<meta\s+property="og:url"\s+content=")([^"]*)(">)/i,
+      /(<meta\s+property="og:url"\s+content=")([^"]*)("\s*>)/i,
       `$1${canonicalUrl}$3`
     );
   }
@@ -237,7 +238,7 @@ function maintenancePage() {
   });
 }
 
-// ── Main Handler ─────────────────────────────────────────────────────────
+// ── Main Handler ───────────────────────────────────────���─────────────────
 
 export default {
   async fetch(request, env, ctx) {
@@ -247,6 +248,26 @@ export default {
 
     // Serve our own robots.txt for the canonical domain
     if (url.pathname === '/robots.txt') return robotsTxt();
+
+    // Proxy /v1/* API calls to the gateway worker
+    if (url.pathname.startsWith('/v1/')) {
+      const apiUrl = API_GATEWAY_ORIGIN + url.pathname + url.search;
+      const apiHeaders = new Headers(request.headers);
+      apiHeaders.set('Host', new URL(API_GATEWAY_ORIGIN).hostname);
+      apiHeaders.set('X-Forwarded-Host', siteHost);
+      try {
+        return await fetch(apiUrl, {
+          method: request.method,
+          headers: apiHeaders,
+          body: request.method !== 'GET' && request.method !== 'HEAD' ? request.body : undefined,
+        });
+      } catch (err) {
+        return new Response(JSON.stringify({ error: 'API gateway unreachable' }), {
+          status: 502,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
 
     // Build target URL
     const targetUrl = MANUS_ORIGIN + url.pathname + url.search;

--- a/ck-website/custom-domains.json
+++ b/ck-website/custom-domains.json
@@ -1,0 +1,42 @@
+{
+  "project": "thg-app",
+  "pagesUrl": "thg-app.pages.dev",
+  "customDomains": [
+    {
+      "domain": "app.traceyhuntergroup.com",
+      "type": "CNAME",
+      "target": "thg-app.pages.dev",
+      "proxied": true,
+      "ssl": "full",
+      "status": "pending"
+    }
+  ],
+  "dnsRecords": [
+    {
+      "type": "CNAME",
+      "name": "app",
+      "content": "thg-app.pages.dev",
+      "proxied": true,
+      "comment": "THG App — Cloudflare Pages custom domain"
+    }
+  ],
+  "verification": {
+    "steps": [
+      "1. Go to dash.cloudflare.com > Pages > thg-app > Custom domains",
+      "2. Click 'Set up a custom domain'",
+      "3. Enter: app.traceyhuntergroup.com",
+      "4. Cloudflare auto-creates the CNAME if the zone is on Cloudflare",
+      "5. Wait for SSL certificate provisioning (usually < 5 minutes)",
+      "6. Run: npm run test:domain to verify everything works"
+    ]
+  },
+  "expectedHeaders": {
+    "x-frame-options": "DENY",
+    "x-content-type-options": "nosniff",
+    "referrer-policy": "strict-origin-when-cross-origin"
+  },
+  "expectedRedirects": {
+    "https://www.traceyhuntergroup.com": "https://app.traceyhuntergroup.com",
+    "http://app.traceyhuntergroup.com": "https://app.traceyhuntergroup.com"
+  }
+}

--- a/tests/app-smoke.test.js
+++ b/tests/app-smoke.test.js
@@ -1,0 +1,191 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Coastal Key Website — Smoke Tests
+ *
+ * Validates that the website reverse proxy, API gateway proxy,
+ * security headers, and subdomain consolidation are properly configured.
+ *
+ * Run: node --test tests/app-smoke.test.js
+ */
+
+const WEBSITE_DIR = resolve(import.meta.dirname, '..', 'ck-website');
+
+function readFile(relativePath) {
+  return readFileSync(resolve(WEBSITE_DIR, relativePath), 'utf-8');
+}
+
+function fileExists(relativePath) {
+  return existsSync(resolve(WEBSITE_DIR, relativePath));
+}
+
+// ── Reverse Proxy Worker ──
+
+describe('Reverse proxy worker', () => {
+  let workerCode;
+
+  before(() => {
+    workerCode = readFile('_worker.js');
+  });
+
+  it('should define Manus origin', () => {
+    assert.ok(workerCode.includes('MANUS_ORIGIN'), 'MANUS_ORIGIN constant required');
+    assert.ok(workerCode.includes('manus.space'), 'must point to Manus origin');
+  });
+
+  it('should define canonical domain', () => {
+    assert.ok(workerCode.includes('coastalkey-pm.com'), 'canonical domain required');
+  });
+
+  it('should define API gateway origin', () => {
+    assert.ok(workerCode.includes('API_GATEWAY_ORIGIN'), 'API_GATEWAY_ORIGIN constant required');
+  });
+
+  it('should proxy /v1/* to API gateway', () => {
+    assert.ok(workerCode.includes("/v1/"), 'must check for /v1/ prefix');
+    assert.ok(workerCode.includes('API_GATEWAY_ORIGIN'), 'must route to API gateway');
+  });
+
+  it('should serve custom robots.txt', () => {
+    assert.ok(workerCode.includes('robots.txt'), 'must handle robots.txt');
+  });
+
+  it('should rewrite URLs in responses', () => {
+    assert.ok(workerCode.includes('rewriteUrls') || workerCode.includes('replaceAll'),
+      'must rewrite origin URLs in responses');
+  });
+
+  it('should set security headers', () => {
+    assert.ok(workerCode.includes('X-Content-Type-Options'), 'X-Content-Type-Options required');
+    assert.ok(workerCode.includes('Strict-Transport-Security'), 'HSTS required');
+    assert.ok(workerCode.includes('Referrer-Policy'), 'Referrer-Policy required');
+  });
+
+  it('should handle upstream failures gracefully', () => {
+    assert.ok(workerCode.includes('catch') || workerCode.includes('maintenancePage'),
+      'must have error handling');
+  });
+
+  it('should use ES module export format', () => {
+    assert.ok(workerCode.includes('export default'), 'must use ES module default export');
+  });
+
+  it('should implement edge caching', () => {
+    assert.ok(workerCode.includes('Cache-Control'), 'must set Cache-Control headers');
+    assert.ok(workerCode.includes('max-age'), 'must set max-age for caching');
+  });
+});
+
+// ── API Gateway Proxy ──
+
+describe('API gateway proxy', () => {
+  let workerCode;
+
+  before(() => {
+    workerCode = readFile('_worker.js');
+  });
+
+  it('should return 502 when gateway is unreachable', () => {
+    assert.ok(workerCode.includes('502'), 'must return 502 on gateway failure');
+    assert.ok(workerCode.includes('API gateway unreachable') || workerCode.includes('unreachable'),
+      'must indicate gateway is unreachable');
+  });
+
+  it('should forward request method to gateway', () => {
+    assert.ok(workerCode.includes('request.method'), 'must forward request method');
+  });
+
+  it('should set Host header for gateway', () => {
+    assert.ok(workerCode.includes("'Host'") || workerCode.includes('"Host"'),
+      'must set Host header for gateway');
+  });
+});
+
+// ── Security Headers ──
+
+describe('Cloudflare Pages _headers file', () => {
+  let headersContent;
+
+  before(() => {
+    headersContent = readFile('_headers');
+  });
+
+  it('should set X-Content-Type-Options to nosniff', () => {
+    assert.ok(headersContent.includes('X-Content-Type-Options: nosniff'),
+      'X-Content-Type-Options header required');
+  });
+
+  it('should set Referrer-Policy', () => {
+    assert.ok(headersContent.includes('Referrer-Policy:'), 'Referrer-Policy required');
+  });
+
+  it('should set HSTS', () => {
+    assert.ok(headersContent.includes('Strict-Transport-Security:'), 'HSTS required');
+  });
+
+  it('should set Permissions-Policy', () => {
+    assert.ok(headersContent.includes('Permissions-Policy:'), 'Permissions-Policy required');
+  });
+
+  it('should not cache index.html', () => {
+    assert.ok(headersContent.includes('no-cache'), 'index.html should have no-cache');
+  });
+});
+
+// ── Subdomain Consolidation ──
+
+describe('Cloudflare Pages _redirects file', () => {
+  let redirectsContent;
+
+  before(() => {
+    redirectsContent = readFile('_redirects');
+  });
+
+  it('should redirect www to primary domain', () => {
+    assert.ok(redirectsContent.includes('www.coastalkey-pm.com'),
+      'www subdomain redirect required');
+  });
+
+  it('should use 301 permanent redirects for subdomains', () => {
+    assert.ok(redirectsContent.includes('301'), 'should use 301 redirects');
+  });
+
+  it('should consolidate all known subdomains', () => {
+    const subdomains = ['www', 'app', 'dashboard', 'agents', 'api', 'admin', 'staging', 'dev', 'beta'];
+    for (const sub of subdomains) {
+      assert.ok(redirectsContent.includes(`${sub}.coastalkey-pm.com`),
+        `${sub} subdomain redirect missing`);
+    }
+  });
+});
+
+// ── Website Structure ──
+
+describe('Website file structure', () => {
+  it('should have _worker.js reverse proxy', () => {
+    assert.ok(fileExists('_worker.js'), '_worker.js required');
+  });
+
+  it('should have _headers file', () => {
+    assert.ok(fileExists('_headers'), '_headers required');
+  });
+
+  it('should have _redirects file', () => {
+    assert.ok(fileExists('_redirects'), '_redirects required');
+  });
+
+  it('should have index.html', () => {
+    assert.ok(fileExists('index.html'), 'index.html required');
+  });
+
+  it('should have wrangler.toml', () => {
+    assert.ok(fileExists('wrangler.toml'), 'wrangler.toml required');
+  });
+
+  it('should have custom-domains.json', () => {
+    assert.ok(fileExists('custom-domains.json'), 'custom-domains.json required');
+  });
+});

--- a/tests/domain-validation.test.js
+++ b/tests/domain-validation.test.js
@@ -1,0 +1,205 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Custom Domain Validation Tests
+ *
+ * Validates that the THG app custom domain (app.traceyhuntergroup.com)
+ * is properly configured with correct DNS, SSL, headers, and redirects.
+ *
+ * Run: node --test tests/domain-validation.test.js
+ *
+ * Modes:
+ *   - Offline (default): validates config files and structure
+ *   - Live (LIVE_DOMAIN_TEST=1): makes real HTTP requests to verify the domain
+ */
+
+const CONFIG_PATH = resolve(import.meta.dirname, '..', 'ck-website', 'custom-domains.json');
+const HEADERS_PATH = resolve(import.meta.dirname, '..', 'ck-website', '_headers');
+const REDIRECTS_PATH = resolve(import.meta.dirname, '..', 'ck-website', '_redirects');
+
+const isLive = process.env.LIVE_DOMAIN_TEST === '1';
+const DOMAIN = process.env.TEST_DOMAIN || 'app.traceyhuntergroup.com';
+const PAGES_URL = 'thg-app.pages.dev';
+
+// ── Helper: fetch with timeout ──────────────────────────────────────────────
+async function fetchWithTimeout(url, opts = {}, timeoutMs = 10000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { ...opts, signal: controller.signal, redirect: 'manual' });
+    return res;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ── Helper: DNS lookup via DoH (Cloudflare) ─────────────────────────────────
+async function dnsLookup(name, type = 'CNAME') {
+  const url = `https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(name)}&type=${type}`;
+  const res = await fetchWithTimeout(url, {
+    headers: { 'Accept': 'application/dns-json' },
+  });
+  return res.json();
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Config Validation (always runs)
+// ═���════════════════��═══════════════════════════════��════════════════════════════
+
+describe('Custom domain configuration', () => {
+  let config;
+
+  before(() => {
+    const raw = readFileSync(CONFIG_PATH, 'utf-8');
+    config = JSON.parse(raw);
+  });
+
+  it('should have a valid custom-domains.json', () => {
+    assert.ok(config.project, 'project name is required');
+    assert.ok(config.pagesUrl, 'pagesUrl is required');
+    assert.ok(Array.isArray(config.customDomains), 'customDomains must be an array');
+    assert.ok(config.customDomains.length > 0, 'at least one custom domain required');
+  });
+
+  it('should define app.traceyhuntergroup.com as a custom domain', () => {
+    const thgDomain = config.customDomains.find(d => d.domain === 'app.traceyhuntergroup.com');
+    assert.ok(thgDomain, 'app.traceyhuntergroup.com must be listed');
+    assert.equal(thgDomain.type, 'CNAME', 'should use CNAME record');
+    assert.equal(thgDomain.target, PAGES_URL, 'should point to Pages URL');
+    assert.equal(thgDomain.ssl, 'full', 'should use full SSL');
+    assert.equal(thgDomain.proxied, true, 'should be proxied through Cloudflare');
+  });
+
+  it('should have DNS records configured', () => {
+    assert.ok(Array.isArray(config.dnsRecords), 'dnsRecords must be an array');
+    const cname = config.dnsRecords.find(r => r.type === 'CNAME' && r.name === 'app');
+    assert.ok(cname, 'CNAME record for app subdomain must exist');
+    assert.equal(cname.content, PAGES_URL, 'CNAME must point to Pages URL');
+  });
+
+  it('should have verification steps documented', () => {
+    assert.ok(config.verification, 'verification section required');
+    assert.ok(Array.isArray(config.verification.steps), 'verification steps must be an array');
+    assert.ok(config.verification.steps.length >= 3, 'at least 3 verification steps');
+  });
+
+  it('should define expected security headers', () => {
+    assert.ok(config.expectedHeaders, 'expectedHeaders required');
+    assert.equal(config.expectedHeaders['x-frame-options'], 'DENY');
+    assert.equal(config.expectedHeaders['x-content-type-options'], 'nosniff');
+  });
+});
+
+describe('Cloudflare Pages _headers file', () => {
+  let headersContent;
+
+  before(() => {
+    headersContent = readFileSync(HEADERS_PATH, 'utf-8');
+  });
+
+  it('should set X-Content-Type-Options to nosniff', () => {
+    assert.ok(headersContent.includes('X-Content-Type-Options: nosniff'), 'X-Content-Type-Options header missing');
+  });
+
+  it('should set Referrer-Policy', () => {
+    assert.ok(headersContent.includes('Referrer-Policy:'), 'Referrer-Policy header missing');
+  });
+
+  it('should set HSTS header', () => {
+    assert.ok(headersContent.includes('Strict-Transport-Security:'), 'HSTS header missing');
+  });
+
+  it('should not cache index.html', () => {
+    assert.ok(headersContent.includes('no-cache'), 'index.html should have no-cache');
+  });
+});
+
+describe('Cloudflare Pages _redirects file', () => {
+  let redirectsContent;
+
+  before(() => {
+    redirectsContent = readFileSync(REDIRECTS_PATH, 'utf-8');
+  });
+
+  it('should consolidate subdomains to primary domain', () => {
+    assert.ok(redirectsContent.includes('www.coastalkey-pm.com'), 'www subdomain redirect missing');
+    assert.ok(redirectsContent.includes('301'), 'subdomain redirects should use 301');
+  });
+
+  it('should consolidate all known subdomains', () => {
+    const subdomains = ['www', 'app', 'dashboard', 'agents', 'api', 'admin'];
+    for (const sub of subdomains) {
+      assert.ok(redirectsContent.includes(`${sub}.coastalkey-pm.com`), `${sub} subdomain redirect missing`);
+    }
+  });
+});
+
+// ═════��════════════════════════════════��════════════════════════════════════════
+// Live Domain Validation (only when LIVE_DOMAIN_TEST=1)
+// ══���═════════��══════════════════════════════════════════════════════════════════
+
+describe('Live domain validation', { skip: !isLive && 'Set LIVE_DOMAIN_TEST=1 to run live tests' }, () => {
+
+  it('should resolve DNS CNAME to Pages URL', async () => {
+    const result = await dnsLookup(DOMAIN, 'CNAME');
+    const hasRecords = result.Answer && result.Answer.length > 0;
+    assert.ok(hasRecords || result.Status === 0, `DNS for ${DOMAIN} should resolve (got status ${result.Status})`);
+  });
+
+  it('should serve HTTPS with valid certificate', async () => {
+    const res = await fetchWithTimeout(`https://${DOMAIN}/`);
+    assert.ok(res.ok, `HTTPS request to ${DOMAIN} should succeed (got ${res.status})`);
+  });
+
+  it('should return correct security headers', async () => {
+    const res = await fetchWithTimeout(`https://${DOMAIN}/`);
+    assert.equal(
+      res.headers.get('x-frame-options')?.toUpperCase(),
+      'DENY',
+      'X-Frame-Options should be DENY'
+    );
+    assert.equal(
+      res.headers.get('x-content-type-options'),
+      'nosniff',
+      'X-Content-Type-Options should be nosniff'
+    );
+  });
+
+  it('should redirect HTTP to HTTPS', async () => {
+    const res = await fetchWithTimeout(`http://${DOMAIN}/`, {}, 10000);
+    assert.ok(
+      [301, 302, 308].includes(res.status),
+      `HTTP should redirect to HTTPS (got ${res.status})`
+    );
+    const location = res.headers.get('location') || '';
+    assert.ok(location.startsWith('https://'), `Should redirect to HTTPS (got ${location})`);
+  });
+
+  it('should serve HTML content on root path', async () => {
+    const res = await fetchWithTimeout(`https://${DOMAIN}/`);
+    const contentType = res.headers.get('content-type') || '';
+    assert.ok(contentType.includes('text/html'), `Root should serve HTML (got ${contentType})`);
+  });
+
+  it('should handle SPA routing (return 200 for unknown paths)', async () => {
+    const res = await fetchWithTimeout(`https://${DOMAIN}/some/app/route`);
+    assert.equal(res.status, 200, 'SPA routes should return 200');
+    const contentType = res.headers.get('content-type') || '';
+    assert.ok(contentType.includes('text/html'), 'SPA routes should serve HTML');
+  });
+
+  it('should cache static assets with immutable headers', async () => {
+    const res = await fetchWithTimeout(`https://${DOMAIN}/src/styles/main.css`);
+    assert.equal(res.status, 200, 'Static CSS should return 200');
+    const cacheControl = res.headers.get('cache-control') || '';
+    assert.ok(cacheControl.includes('immutable'), `Static assets should be immutable (got ${cacheControl})`);
+  });
+
+  it('Pages URL should still be accessible', async () => {
+    const res = await fetchWithTimeout(`https://${PAGES_URL}/`);
+    assert.ok(res.ok, `Pages URL ${PAGES_URL} should remain accessible`);
+  });
+});


### PR DESCRIPTION
## Summary

Production go-live — adds API gateway proxy, custom domain configuration, and comprehensive test coverage on top of main.

### Changes (5 files)

- **`ck-website/_worker.js`**: Add `/v1/*` route handler that proxies API calls to `ck-api-gateway` worker. Without this, all `/v1/*` requests go to Manus origin and 404. Enables contact form, podcast feed, and all authenticated API endpoints from `coastalkey-pm.com`.

- **`ck-website/custom-domains.json`**: THG app custom domain config for `app.traceyhuntergroup.com` — CNAME to `thg-app.pages.dev` with SSL/proxy settings and verification steps.

- **`ck-api-gateway/src/__tests__/gateway.test.js`**: Add Airtable TABLES constant validation (core tables present, IDs follow `tbl*` format) and Buffer service export tests (5 function exports verified).

- **`tests/domain-validation.test.js`**: Custom domain config validation, security headers, subdomain consolidation, plus live domain checks (gated behind `LIVE_DOMAIN_TEST=1`).

- **`tests/app-smoke.test.js`**: Reverse proxy worker validation (Manus origin, API gateway proxy, security headers, caching), file structure checks.

### Test Results

All 604 tests pass: 106 server + 486 gateway + 6 sentinel + 6 nemotron.

## Test plan

- [x] All 604 tests pass locally
- [x] `/v1/*` proxy routes to API gateway (not Manus)
- [x] Custom domain config validates correctly
- [x] Security headers validated in _headers
- [x] Subdomain consolidation validated in _redirects
- [ ] Post-merge: verify `coastalkey-pm.com/v1/health` returns 200
- [ ] Post-merge: verify `coastalkey-pm.com/v1/podcast/feed.xml` serves RSS

https://claude.ai/code/session_013PAvPdD2h1ayNwGWQ7efuX

---
_Generated by [Claude Code](https://claude.ai/code/session_013PAvPdD2h1ayNwGWQ7efuX)_