### PR TITLE
Fix smoke-test commit-back: race-safe push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -180,6 +180,10 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: true
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -308,7 +312,20 @@ jobs:
           git add deploy-status.json
           if git diff --cached --quiet; then
             echo "No status change."
-          else
-            git commit -m "Record live deploy verification for ${{ github.sha }} [skip ci]"
-            git push
+            exit 0
           fi
+          git commit -m "Record live deploy verification for ${{ github.sha }} [skip ci]"
+          # Race-safe push: rebase against any commits that landed on main during the
+          # ~5-min deploy window, then push explicitly to main. Loop on conflict.
+          for attempt in 1 2 3 4; do
+            git fetch origin main
+            git rebase origin/main || { git rebase --abort; echo "Rebase failed on attempt $attempt"; sleep 5; continue; }
+            if git push origin HEAD:main; then
+              echo "deploy-status.json committed back to main on attempt $attempt"
+              exit 0
+            fi
+            echo "Push attempt $attempt rejected (likely non-fast-forward), retrying in 5s..."
+            sleep 5
+          done
+          echo "::error::Failed to commit deploy-status.json after 4 attempts"
+          exit 1


### PR DESCRIPTION
## Problem

`deploy-status.json` on main is stuck at commit `5ea49a47` (`2026-05-02T13:41:10Z`) despite ~10 subsequent commits landing on main (PR batch #47-55, mobile app batches, master prompt restore, website go-live, etc.).

The smoke-test job is firing on every push, but the bare `git push` fails as non-fast-forward when other commits land during the ~5-minute deploy window. Failure is silent — job exits 0 even though the commit-back didn't happen.

**Evidence:** zero `[skip ci]` commits authored by `github-actions[bot]` in the last 30 commits on main, despite many pushes that should have produced them.

## Three Defects Fixed

| # | Defect | Symptom | Fix |
|---|---|---|---|
| 1 | `actions/checkout@v4` on push events checks out by SHA → detached HEAD | Bare `git push` fails (no upstream tracked) | `with: { ref: main, fetch-depth: 0, persist-credentials: true }` |
| 2 | Bare `git push` rejected as non-fast-forward during ~5-min deploy window | Push fails silently, file stays stale | 4-attempt loop with `git fetch origin main` + `git rebase origin/main` + `git push origin HEAD:main` |
| 3 | Silent failure on final push rejection | No CI signal that commit-back failed | Explicit `::error::` emission after 4 failed attempts |

## Net Effect

Every push to main will reliably update `deploy-status.json` with the latest liveness signals — now including the `website` and `commandCenter` blocks from the prior smoke-test extension that already shipped.

## Why This Matters for Go-Live

`deploy-status.json` is the canonical, repo-readable surface that confirms each push to main is actually live in production. Without it updating, humans and AI agents (including this one) have no programmatic verification that recent deploys succeeded — they have to read GitHub Actions UI manually. This PR closes that observability gap.

## Test Plan

- [ ] CI gates pass (`Test`, `Spec build + content policy`)
- [ ] Merge to main → full deploy chain fires
- [ ] Smoke-test runs after deploys complete
- [ ] **`[skip ci]` commit lands on main with current ISO timestamp**
- [ ] `deploy-status.json` shows `commit: a116f298...` (or whatever the merge SHA is)
- [ ] All five `liveness` blocks populated: gateway, nemotron, sentinel, website, commandCenter

## Risk

Low. Workflow-only change, additive parameters + retry loop. No existing successful behavior altered (smoke-test commit-back was failing silently — this PR makes the success path actually work and the failure path emit a CI error).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Spv66hWnY419nU7fJp6qx4)_